### PR TITLE
Remove downloads from {covidregionaldata} in R files

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -6,6 +6,7 @@ linters: linters_with_tags(
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
     function_argument_linter = NULL,
+    indentation_linter = NULL, # unstable as of lintr 3.1.0
     # Use minimum R declared in DESCRIPTION or fall back to current R version
     backport_linter(if (length(x <- etdev::extract_min_r_version())) x else getRversion())
   )

--- a/R/estimate_reporting.R
+++ b/R/estimate_reporting.R
@@ -27,10 +27,13 @@
 #' @examples
 #' library(cfr)
 #' library(epiparameter)
-#' library(covidregionaldata)
 #'
-#' df_covid_uk <- get_national_data(
-#'   countries = "united kingdom", source = "who", verbose = FALSE
+#' df_covid_uk <- incidence2::covidregionaldataUK
+#' # aggregate the covid data for the UK as a whole
+#' df_covid_uk <- aggregate(
+#'   data = df_covid_uk,
+#'   x = cbind(cases_new, deaths_new) ~ date,
+#'   FUN = function(x) sum(x, na.rm = TRUE)
 #' )
 #' # rename columns
 #' colnames(df_covid_uk)[colnames(df_covid_uk) == "cases_new"] <- "cases"

--- a/R/estimate_reporting.R
+++ b/R/estimate_reporting.R
@@ -25,23 +25,24 @@
 #' @export
 #'
 #' @examples
-#' library(cfr)
-#' library(epiparameter)
-#'
+#' # get data pre-loaded with {incidence2}
 #' df_covid_uk <- incidence2::covidregionaldataUK
+#'
 #' # aggregate the covid data for the UK as a whole
 #' df_covid_uk <- aggregate(
 #'   data = df_covid_uk,
 #'   x = cbind(cases_new, deaths_new) ~ date,
 #'   FUN = function(x) sum(x, na.rm = TRUE)
 #' )
+#'
 #' # rename columns
 #' colnames(df_covid_uk)[colnames(df_covid_uk) == "cases_new"] <- "cases"
 #' colnames(df_covid_uk)[colnames(df_covid_uk) == "deaths_new"] <- "deaths"
 #'
 #' df_covid_uk_subset <- subset(df_covid_uk, date <= "2020-05-31")
 #'
-#' onset_to_death_covid <- epidist_db(
+#' # load epidist object from {epiparameter}
+#' onset_to_death_covid <- epiparameter::epidist_db(
 #'   disease = "COVID-19",
 #'   epi_dist = "onset_to_death",
 #'   author = "Linton_etal"

--- a/R/estimate_reporting.R
+++ b/R/estimate_reporting.R
@@ -142,12 +142,11 @@ estimate_reporting <- function(data,
   # here, the estimate called "severity_me" translates to "reporting_me"
   # and the estimate "severity_hi" translates to "reporting_lo"
   # TODO: check if this is correct
-  df_out <- data.frame(
-    reporting_me = df_out$severity_me,
-    reporting_lo = df_out$severity_hi,
-    reporting_hi = df_out$severity_lo
+  df_out <- as.data.frame(df_out,
+    row.names = NULL,
+    col.names = c("reporting_me", "reporting_hi", "reporting_lo")
   )
 
-  # return data
-  df_out
+  # return data with columns in correct order
+  df_out[, c("reporting_me", "reporting_lo", "reporting_hi")]
 }

--- a/R/estimate_time_varying.R
+++ b/R/estimate_time_varying.R
@@ -33,32 +33,48 @@
 #' @export
 #'
 #' @examples
-#' # load package data
-#' data("ebola1976")
+#' # get data pre-loaded with {incidence2}
+#' df_covid_uk <- incidence2::covidregionaldataUK
 #'
-#' # get an onset to death distribution from the {epiparameter} package
-#' onset_to_death_ebola <- epiparameter::epidist_db(
-#'   disease = "Ebola Virus Disease",
+#' # aggregate the covid data for the UK as a whole
+#' df_covid_uk <- aggregate(
+#'   data = df_covid_uk,
+#'   x = cbind(cases_new, deaths_new) ~ date,
+#'   FUN = function(x) sum(x, na.rm = TRUE)
+#' )
+#'
+#' # rename columns
+#' colnames(df_covid_uk)[colnames(df_covid_uk) == "cases_new"] <- "cases"
+#' colnames(df_covid_uk)[colnames(df_covid_uk) == "deaths_new"] <- "deaths"
+#'
+#' df_covid_uk_subset <- subset(df_covid_uk, date <= "2020-05-31")
+#'
+#' # load epidist object from {epiparameter}
+#' onset_to_death_covid <- epiparameter::epidist_db(
+#'   disease = "COVID-19",
 #'   epi_dist = "onset_to_death",
-#'   author = "Barry_etal"
+#'   author = "Linton_etal"
 #' )
 #'
 #' # estimate time varying severity without correcting for delays
-#' estimate_time_varying(
-#'   data = ebola1976,
+#' cfr_time_varying <- estimate_time_varying(
+#'   data = df_covid_uk_subset,
 #'   smooth_inputs = TRUE,
 #'   burn_in_value = 7L,
 #'   correct_for_delays = FALSE
 #' )
+#' # View
+#' tail(cfr_time_varying)
 #'
 #' # estimate time varying severity while correcting for delays
-#' estimate_time_varying(
-#'   data = ebola1976,
-#'   epi_dist = onset_to_death_ebola,
+#' cfr_time_varying <- estimate_time_varying(
+#'   data = df_covid_uk_subset,
+#'   epi_dist = onset_to_death_covid,
 #'   smooth_inputs = TRUE,
 #'   burn_in_value = 7L,
 #'   correct_for_delays = TRUE
 #' )
+#' tail(cfr_time_varying)
 #'
 estimate_time_varying <- function(data,
                                   epi_dist = NULL,

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -67,7 +67,7 @@ prepare_data <- function(data, ...) {
 #' )
 #'
 #' # View head of prepared data
-#' head(
+#' tail(
 #'   prepare_data(
 #'     covid_uk_incidence,
 #'     cases_variable = "cases_new",

--- a/man/estimate_reporting.Rd
+++ b/man/estimate_reporting.Rd
@@ -87,23 +87,24 @@ ascertainment estimate is calculated as the ratio of the baseline severity
 estimate and the delay-adjusted severity estimate
 }
 \examples{
-library(cfr)
-library(epiparameter)
-
+# get data pre-loaded with {incidence2}
 df_covid_uk <- incidence2::covidregionaldataUK
+
 # aggregate the covid data for the UK as a whole
 df_covid_uk <- aggregate(
   data = df_covid_uk,
   x = cbind(cases_new, deaths_new) ~ date,
   FUN = function(x) sum(x, na.rm = TRUE)
 )
+
 # rename columns
 colnames(df_covid_uk)[colnames(df_covid_uk) == "cases_new"] <- "cases"
 colnames(df_covid_uk)[colnames(df_covid_uk) == "deaths_new"] <- "deaths"
 
 df_covid_uk_subset <- subset(df_covid_uk, date <= "2020-05-31")
 
-onset_to_death_covid <- epidist_db(
+# load epidist object from {epiparameter}
+onset_to_death_covid <- epiparameter::epidist_db(
   disease = "COVID-19",
   epi_dist = "onset_to_death",
   author = "Linton_etal"

--- a/man/estimate_reporting.Rd
+++ b/man/estimate_reporting.Rd
@@ -89,10 +89,13 @@ estimate and the delay-adjusted severity estimate
 \examples{
 library(cfr)
 library(epiparameter)
-library(covidregionaldata)
 
-df_covid_uk <- get_national_data(
-  countries = "united kingdom", source = "who", verbose = FALSE
+df_covid_uk <- incidence2::covidregionaldataUK
+# aggregate the covid data for the UK as a whole
+df_covid_uk <- aggregate(
+  data = df_covid_uk,
+  x = cbind(cases_new, deaths_new) ~ date,
+  FUN = function(x) sum(x, na.rm = TRUE)
 )
 # rename columns
 colnames(df_covid_uk)[colnames(df_covid_uk) == "cases_new"] <- "cases"

--- a/man/estimate_time_varying.Rd
+++ b/man/estimate_time_varying.Rd
@@ -70,31 +70,47 @@ distribution representing the delay between case detection and death, then
 a case fatality ratio over time is estimated
 }
 \examples{
-# load package data
-data("ebola1976")
+# get data pre-loaded with {incidence2}
+df_covid_uk <- incidence2::covidregionaldataUK
 
-# get an onset to death distribution from the {epiparameter} package
-onset_to_death_ebola <- epiparameter::epidist_db(
-  disease = "Ebola Virus Disease",
+# aggregate the covid data for the UK as a whole
+df_covid_uk <- aggregate(
+  data = df_covid_uk,
+  x = cbind(cases_new, deaths_new) ~ date,
+  FUN = function(x) sum(x, na.rm = TRUE)
+)
+
+# rename columns
+colnames(df_covid_uk)[colnames(df_covid_uk) == "cases_new"] <- "cases"
+colnames(df_covid_uk)[colnames(df_covid_uk) == "deaths_new"] <- "deaths"
+
+df_covid_uk_subset <- subset(df_covid_uk, date <= "2020-05-31")
+
+# load epidist object from {epiparameter}
+onset_to_death_covid <- epiparameter::epidist_db(
+  disease = "COVID-19",
   epi_dist = "onset_to_death",
-  author = "Barry_etal"
+  author = "Linton_etal"
 )
 
 # estimate time varying severity without correcting for delays
-estimate_time_varying(
-  data = ebola1976,
+cfr_time_varying <- estimate_time_varying(
+  data = df_covid_uk_subset,
   smooth_inputs = TRUE,
   burn_in_value = 7L,
   correct_for_delays = FALSE
 )
+# View
+tail(cfr_time_varying)
 
 # estimate time varying severity while correcting for delays
-estimate_time_varying(
-  data = ebola1976,
-  epi_dist = onset_to_death_ebola,
+cfr_time_varying <- estimate_time_varying(
+  data = df_covid_uk_subset,
+  epi_dist = onset_to_death_covid,
   smooth_inputs = TRUE,
   burn_in_value = 7L,
   correct_for_delays = TRUE
 )
+tail(cfr_time_varying)
 
 }

--- a/man/prepare_data.incidence2.Rd
+++ b/man/prepare_data.incidence2.Rd
@@ -30,7 +30,7 @@ data.}
 }
 \value{
 A data.frame suitable for disease severity estimation functions
-provided in \code{{cfr}}, with the columns "date", "cases", and "deaths".
+provided in \pkg{cfr}, with the columns "date", "cases", and "deaths".
 Note that groups in \verb{<incidence2>} are not retained, and cases and deaths
 are summed by date.
 The result has a continuous sequence of dates between the start and end date

--- a/man/prepare_data.incidence2.Rd
+++ b/man/prepare_data.incidence2.Rd
@@ -68,7 +68,7 @@ covid_uk_incidence <- incidence2::incidence(
 )
 
 # View head of prepared data
-head(
+tail(
   prepare_data(
     covid_uk_incidence,
     cases_variable = "cases_new",

--- a/tests/testthat/_snaps/estimate_reporting.md
+++ b/tests/testthat/_snaps/estimate_reporting.md
@@ -43,6 +43,6 @@
     Code
       reporting_estimate
     Output
-         reporting_me reporting_lo reporting_hi
-      73        0.014        0.014         0.56
+        reporting_me reporting_lo reporting_hi
+      1        0.014        0.014         0.56
 


### PR DESCRIPTION
This PR is a WIP on issue #51, and removes data download steps in the function examples and tests. This reduces the time taken for checks to run when internet connections are slow, and works towards reducing the dependency on {covidregionaldata}.

The use of {covidregionaldata} in the vignettes is further reduced in PR #55, but not entirely avoided, pending the outcome of an ongoing discussion: https://github.com/orgs/epiverse-trace/discussions/85