### PR TITLE
Rename fun arg epi_dist to epidist

### DIFF
--- a/R/estimate_ascertainment.R
+++ b/R/estimate_ascertainment.R
@@ -52,7 +52,7 @@
 #'
 #' estimate_ascertainment(
 #'   data = df_covid_uk,
-#'   epi_dist = onset_to_death_covid,
+#'   epidist = onset_to_death_covid,
 #'   type = "varying",
 #'   severity_baseline = 0.014,
 #'   smooth_inputs = TRUE,
@@ -62,11 +62,11 @@
 #' )
 #'
 estimate_ascertainment <- function(data,
-                                   epi_dist = NULL,
+                                   epidist = NULL,
                                    type = c("static", "varying"),
                                    severity_baseline = 0.014,
                                    burn_in_value = get_default_burn_in(
-                                     epi_dist
+                                     epidist
                                    ),
                                    smooth_inputs = FALSE,
                                    smoothing_window = 1,
@@ -95,7 +95,7 @@ estimate_ascertainment <- function(data,
   )
   checkmate::assert_string(max_date, null.ok = TRUE)
   if (correct_for_delays) {
-    checkmate::assert_class(epi_dist, "epidist")
+    checkmate::assert_class(epidist, "epidist")
   }
 
   # match argument for type
@@ -107,13 +107,13 @@ estimate_ascertainment <- function(data,
   if (type == "static") {
     df_severity <- estimate_static(
       data,
-      epi_dist = epi_dist,
+      epidist = epidist,
       correct_for_delays = correct_for_delays
     )
   } else if (type == "varying") {
     df_severity <- estimate_time_varying(
       data,
-      epi_dist = epi_dist,
+      epidist = epidist,
       smooth_inputs = smooth_inputs,
       smoothing_window = smoothing_window,
       burn_in_value = burn_in_value,

--- a/R/estimate_rolling.R
+++ b/R/estimate_rolling.R
@@ -39,13 +39,13 @@
 #'   estimate_rolling(
 #'     ebola1976,
 #'     correct_for_delays = TRUE,
-#'     epi_dist = onset_to_death_ebola
+#'     epidist = onset_to_death_ebola
 #'   )
 #' )
 #'
 estimate_rolling <- function(data,
                              correct_for_delays = FALSE,
-                             epi_dist = NULL,
+                             epidist = NULL,
                              poisson_threshold = 100) {
 
   # input checking
@@ -79,7 +79,7 @@ estimate_rolling <- function(data,
     # of deaths
     data <- known_outcomes(
       data = data,
-      epi_dist = epi_dist
+      epidist = epidist
     )
 
     # prepare cumulative sums

--- a/R/estimate_static.R
+++ b/R/estimate_static.R
@@ -22,7 +22,7 @@
 #' to a naive severity being calculated, TRUE corresponds to the user
 #' calculating a corrected severity
 #'
-#' @param epi_dist The delay distribution used, in the form of an
+#' @param epidist The delay distribution used, in the form of an
 #' [epiparameter::epidist()] object. This is used to obtain a probability
 #' mass function parameterised by time; i.e. \eqn{f(t)} which gives the
 #' probability a case has a known outcomes (i.e. death) at time \eqn{t},
@@ -58,12 +58,12 @@
 #' estimate_static(
 #'   ebola1976,
 #'   correct_for_delays = TRUE,
-#'   epi_dist = onset_to_death_ebola
+#'   epidist = onset_to_death_ebola
 #' )
 #'
 estimate_static <- function(data,
                             correct_for_delays = FALSE,
-                            epi_dist = NULL,
+                            epidist = NULL,
                             poisson_threshold = 100) {
   # input checking
   checkmate::assert_data_frame(data)
@@ -90,7 +90,7 @@ estimate_static <- function(data,
   # returns error message if no delay distribution is supplied, but correction
   # for delays was requested
   if (correct_for_delays) {
-    checkmate::assert_class(epi_dist, "epidist")
+    checkmate::assert_class(epidist, "epidist")
   }
 
   # calculating the naive severity: (total deaths) / (total cases)
@@ -103,7 +103,7 @@ estimate_static <- function(data,
     # used as a replacement for total deaths in the original severity formula
     df_corrected <- known_outcomes(
       data = data,
-      epi_dist = epi_dist
+      epidist = epidist
     )
 
     # calculating the maximum likelihood estimate and 95% confidence interval

--- a/R/estimate_time_varying.R
+++ b/R/estimate_time_varying.R
@@ -69,7 +69,7 @@
 #' # estimate time varying severity while correcting for delays
 #' cfr_time_varying <- estimate_time_varying(
 #'   data = df_covid_uk_subset,
-#'   epi_dist = onset_to_death_covid,
+#'   epidist = onset_to_death_covid,
 #'   smooth_inputs = TRUE,
 #'   burn_in_value = 7L,
 #'   correct_for_delays = TRUE
@@ -77,8 +77,8 @@
 #' tail(cfr_time_varying)
 #'
 estimate_time_varying <- function(data,
-                                  epi_dist = NULL,
-                                  burn_in_value = get_default_burn_in(epi_dist),
+                                  epidist = NULL,
+                                  burn_in_value = get_default_burn_in(epidist),
                                   smooth_inputs = FALSE,
                                   smoothing_window = 1,
                                   correct_for_delays = FALSE) {
@@ -89,7 +89,7 @@ estimate_time_varying <- function(data,
   checkmate::assert_data_frame(data)
   checkmate::assert_logical(correct_for_delays, len = 1L)
   checkmate::assert_integerish(smoothing_window, lower = 1, len = 1L)
-  checkmate::assert_class(epi_dist, "epidist", null.ok = TRUE) # optional arg.
+  checkmate::assert_class(epidist, "epidist", null.ok = TRUE) # optional arg.
 
   stopifnot(
     "Case data must contain columns `cases` and `deaths`" =
@@ -98,7 +98,7 @@ estimate_time_varying <- function(data,
       (smoothing_window %% 2 != 0)
   )
   if (correct_for_delays) {
-    checkmate::assert_class(epi_dist, "epidist")
+    checkmate::assert_class(epidist, "epidist")
   }
 
   # prepare a new dataframe with smoothed columns if requested
@@ -143,7 +143,7 @@ estimate_time_varying <- function(data,
   indices <- seq(case_length - smoothing_window, burn_in_value, -1)
   if (correct_for_delays) {
     pmf_vals <- stats::density(
-      epi_dist,
+      epidist,
       at = seq(from = 0, to = nrow(data) - 1L)
     )
     df_temp[indices, "known_outcomes"] <- vapply(
@@ -189,10 +189,10 @@ estimate_time_varying <- function(data,
 #'
 #' @return A single integer, the burn-in value.
 #' @keywords internal
-get_default_burn_in <- function(epi_dist = NULL) {
-  if (is.null(epi_dist)) {
+get_default_burn_in <- function(epidist = NULL) {
+  if (is.null(epidist)) {
     7
   } else {
-    as.integer(round(epi_dist$summary_stats$centre_spread$mean))
+    as.integer(round(epidist$summary_stats$centre_spread$mean))
   }
 }

--- a/R/known_outcomes.R
+++ b/R/known_outcomes.R
@@ -15,7 +15,7 @@
 #' data on daily deaths, but this column (and any others) will be retained if
 #' present.
 #'
-#' @param epi_dist The delay distribution used, in the form of an
+#' @param epidist The delay distribution used, in the form of an
 #' [epiparameter::epidist()] object. This is used to obtain a probability
 #' mass function parameterised by time; i.e. \eqn{f(t)} which gives the
 #' probability a case has a known outcomes (i.e. death) at time \eqn{t},
@@ -48,7 +48,7 @@
 #'   known_outcomes(data = ebola1976, onset_to_death_ebola)
 #' )
 known_outcomes <- function(data,
-                           epi_dist = NULL) {
+                           epidist = NULL) {
   # some input checking
   stopifnot(
     "Case data must be a data.frame" =
@@ -56,10 +56,10 @@ known_outcomes <- function(data,
     "Case data must contain columns `cases`" =
       "cases" %in% colnames(data)
   )
-  checkmate::assert_class(epi_dist, "epidist")
+  checkmate::assert_class(epidist, "epidist")
 
   pmf_vals <- stats::density(
-    epi_dist,
+    epidist,
     at = seq(from = 0, to = nrow(data) - 1L)
   )
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -77,7 +77,7 @@ estimate_static(data = ebola1976)
 estimate_static(
   data = ebola1976,
   correct_for_delays = TRUE,
-  epi_dist = onset_to_death_ebola
+  epidist = onset_to_death_ebola
 )
 ```
 
@@ -102,7 +102,7 @@ head(rolling_cfr_naive)
 # Calculate the rolling daily CFR while correcting for delays
 rolling_cfr_corrected <- estimate_rolling(
   data = ebola1976, correct_for_delays = TRUE,
-  epi_dist = onset_to_death_ebola
+  epidist = onset_to_death_ebola
 )
 
 # add the date from the outbreak

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ estimate_static(data = ebola1976)
 estimate_static(
   data = ebola1976,
   correct_for_delays = TRUE,
-  epi_dist = onset_to_death_ebola
+  epidist = onset_to_death_ebola
 )
 #>   severity_me severity_lo severity_hi
 #> 1       0.959       0.842           1
@@ -128,7 +128,7 @@ head(rolling_cfr_naive)
 # Calculate the rolling daily CFR while correcting for delays
 rolling_cfr_corrected <- estimate_rolling(
   data = ebola1976, correct_for_delays = TRUE,
-  epi_dist = onset_to_death_ebola
+  epidist = onset_to_death_ebola
 )
 
 # add the date from the outbreak

--- a/man/estimate_ascertainment.Rd
+++ b/man/estimate_ascertainment.Rd
@@ -7,10 +7,10 @@ true) severity estimate}
 \usage{
 estimate_ascertainment(
   data,
-  epi_dist = NULL,
+  epidist = NULL,
   type = c("static", "varying"),
   severity_baseline = 0.014,
-  burn_in_value = get_default_burn_in(epi_dist),
+  burn_in_value = get_default_burn_in(epidist),
   smooth_inputs = FALSE,
   smoothing_window = 1,
   correct_for_delays = FALSE,
@@ -30,7 +30,7 @@ with no missing dates in between. The "date" column must be of the class
 Note also that the total number of cases must be greater than the total
 number of reported deaths.}
 
-\item{epi_dist}{The delay distribution used, in the form of an
+\item{epidist}{The delay distribution used, in the form of an
 \code{\link[epiparameter:epidist]{epiparameter::epidist()}} object. This is used to obtain a probability
 mass function parameterised by time; i.e. \eqn{f(t)} which gives the
 probability a case has a known outcomes (i.e. death) at time \eqn{t},
@@ -114,7 +114,7 @@ onset_to_death_covid <- epiparameter::epidist_db(
 
 estimate_ascertainment(
   data = df_covid_uk,
-  epi_dist = onset_to_death_covid,
+  epidist = onset_to_death_covid,
   type = "varying",
   severity_baseline = 0.014,
   smooth_inputs = TRUE,

--- a/man/estimate_rolling.Rd
+++ b/man/estimate_rolling.Rd
@@ -7,7 +7,7 @@
 estimate_rolling(
   data,
   correct_for_delays = FALSE,
-  epi_dist = NULL,
+  epidist = NULL,
   poisson_threshold = 100
 )
 }
@@ -29,7 +29,7 @@ to correct for the delay between case detection and death. FALSE corresponds
 to a naive severity being calculated, TRUE corresponds to the user
 calculating a corrected severity}
 
-\item{epi_dist}{The delay distribution used, in the form of an
+\item{epidist}{The delay distribution used, in the form of an
 \code{\link[epiparameter:epidist]{epiparameter::epidist()}} object. This is used to obtain a probability
 mass function parameterised by time; i.e. \eqn{f(t)} which gives the
 probability a case has a known outcomes (i.e. death) at time \eqn{t},
@@ -78,7 +78,7 @@ head(
   estimate_rolling(
     ebola1976,
     correct_for_delays = TRUE,
-    epi_dist = onset_to_death_ebola
+    epidist = onset_to_death_ebola
   )
 )
 

--- a/man/estimate_static.Rd
+++ b/man/estimate_static.Rd
@@ -7,7 +7,7 @@
 estimate_static(
   data,
   correct_for_delays = FALSE,
-  epi_dist = NULL,
+  epidist = NULL,
   poisson_threshold = 100
 )
 }
@@ -29,7 +29,7 @@ to correct for the delay between case detection and death. FALSE corresponds
 to a naive severity being calculated, TRUE corresponds to the user
 calculating a corrected severity}
 
-\item{epi_dist}{The delay distribution used, in the form of an
+\item{epidist}{The delay distribution used, in the form of an
 \code{\link[epiparameter:epidist]{epiparameter::epidist()}} object. This is used to obtain a probability
 mass function parameterised by time; i.e. \eqn{f(t)} which gives the
 probability a case has a known outcomes (i.e. death) at time \eqn{t},
@@ -70,7 +70,7 @@ estimate_static(
 estimate_static(
   ebola1976,
   correct_for_delays = TRUE,
-  epi_dist = onset_to_death_ebola
+  epidist = onset_to_death_ebola
 )
 
 }

--- a/man/estimate_time_varying.Rd
+++ b/man/estimate_time_varying.Rd
@@ -6,8 +6,8 @@
 \usage{
 estimate_time_varying(
   data,
-  epi_dist = NULL,
-  burn_in_value = get_default_burn_in(epi_dist),
+  epidist = NULL,
+  burn_in_value = get_default_burn_in(epidist),
   smooth_inputs = FALSE,
   smoothing_window = 1,
   correct_for_delays = FALSE
@@ -26,7 +26,7 @@ with no missing dates in between. The "date" column must be of the class
 Note also that the total number of cases must be greater than the total
 number of reported deaths.}
 
-\item{epi_dist}{The delay distribution used, in the form of an
+\item{epidist}{The delay distribution used, in the form of an
 \code{\link[epiparameter:epidist]{epiparameter::epidist()}} object. This is used to obtain a probability
 mass function parameterised by time; i.e. \eqn{f(t)} which gives the
 probability a case has a known outcomes (i.e. death) at time \eqn{t},
@@ -106,7 +106,7 @@ tail(cfr_time_varying)
 # estimate time varying severity while correcting for delays
 cfr_time_varying <- estimate_time_varying(
   data = df_covid_uk_subset,
-  epi_dist = onset_to_death_covid,
+  epidist = onset_to_death_covid,
   smooth_inputs = TRUE,
   burn_in_value = 7L,
   correct_for_delays = TRUE

--- a/man/get_default_burn_in.Rd
+++ b/man/get_default_burn_in.Rd
@@ -4,10 +4,10 @@
 \alias{get_default_burn_in}
 \title{Get a default burn-in value from a delay distribution}
 \usage{
-get_default_burn_in(epi_dist = NULL)
+get_default_burn_in(epidist = NULL)
 }
 \arguments{
-\item{epi_dist}{The delay distribution used, in the form of an
+\item{epidist}{The delay distribution used, in the form of an
 \code{\link[epiparameter:epidist]{epiparameter::epidist()}} object. This is used to obtain a probability
 mass function parameterised by time; i.e. \eqn{f(t)} which gives the
 probability a case has a known outcomes (i.e. death) at time \eqn{t},

--- a/man/known_outcomes.Rd
+++ b/man/known_outcomes.Rd
@@ -4,7 +4,7 @@
 \alias{known_outcomes}
 \title{Estimate known outcomes from case and death time-series data}
 \usage{
-known_outcomes(data, epi_dist = NULL)
+known_outcomes(data, epidist = NULL)
 }
 \arguments{
 \item{data}{A data.frame containing the outbreak data. A daily time series
@@ -13,7 +13,7 @@ the numbers of new cases at each time point. This function does not require
 data on daily deaths, but this column (and any others) will be retained if
 present.}
 
-\item{epi_dist}{The delay distribution used, in the form of an
+\item{epidist}{The delay distribution used, in the form of an
 \code{\link[epiparameter:epidist]{epiparameter::epidist()}} object. This is used to obtain a probability
 mass function parameterised by time; i.e. \eqn{f(t)} which gives the
 probability a case has a known outcomes (i.e. death) at time \eqn{t},

--- a/tests/testthat/test-estimate_ascertainment.R
+++ b/tests/testthat/test-estimate_ascertainment.R
@@ -49,7 +49,7 @@ test_that("`estimate_ascertainment`: Basic expectations for static method", {
 test_that("`estimate_ascertainment`: Correct for delays for static method", {
   ascertainment_estimate <- estimate_ascertainment(
     data = ebola1976,
-    correct_for_delays = TRUE, epi_dist = onset_to_death_ebola,
+    correct_for_delays = TRUE, epidist = onset_to_death_ebola,
     smooth_inputs = FALSE,
     burn_in_value = 1, smoothing_window = 1,
     type = "static"
@@ -82,7 +82,7 @@ test_that("`estimate_ascertainment`: Correct for delays for static method", {
 test_that("`estimate_ascertainment`: Smooth inputs for static method", {
   ascertainment_estimate <- estimate_ascertainment(
     data = ebola1976,
-    correct_for_delays = FALSE, epi_dist = onset_to_death_ebola,
+    correct_for_delays = FALSE, epidist = onset_to_death_ebola,
     smooth_inputs = TRUE,
     burn_in_value = 1, smoothing_window = 7,
     type = "static"
@@ -115,7 +115,7 @@ test_that("`estimate_ascertainment`: Smooth inputs for static method", {
 test_that("`estimate_ascertainment`: Automatic burn-in value", {
   ascertainment_estimate <- estimate_ascertainment(
     data = ebola1976,
-    correct_for_delays = FALSE, epi_dist = onset_to_death_ebola,
+    correct_for_delays = FALSE, epidist = onset_to_death_ebola,
     smooth_inputs = TRUE,
     smoothing_window = 7,
     type = "static"
@@ -148,7 +148,7 @@ test_that("`estimate_ascertainment`: Automatic burn-in value", {
 test_that("`estimate_ascertainment`: Automatic burn-in value for static", {
   ascertainment_estimate <- estimate_ascertainment(
     data = ebola1976,
-    correct_for_delays = FALSE, epi_dist = onset_to_death_ebola,
+    correct_for_delays = FALSE, epidist = onset_to_death_ebola,
     smooth_inputs = TRUE,
     smoothing_window = 7,
     type = "static"
@@ -182,7 +182,7 @@ test_that("`estimate_ascertainment`: Basic expectations for time-varying", {
   ascertainment_estimate <- estimate_ascertainment(
     data = ebola1976,
     correct_for_delays = TRUE,
-    epi_dist = onset_to_death_ebola,
+    epidist = onset_to_death_ebola,
     smooth_inputs = FALSE,
     type = "varying"
   )

--- a/tests/testthat/test-estimate_rolling.R
+++ b/tests/testthat/test-estimate_rolling.R
@@ -20,7 +20,7 @@ rolling_scfr_naive <- estimate_rolling(
 rolling_scfr_corrected <- estimate_rolling(
   data = ebola1976,
   correct_for_delays = TRUE,
-  epi_dist = onset_to_death_ebola
+  epidist = onset_to_death_ebola
 )
 
 # Basic expectations
@@ -87,7 +87,7 @@ test_that("`estimate_rolling`: Comparison with `estimate_static()`", {
     estimate_static(
       ebola1976,
       correct_for_delays = TRUE,
-      epi_dist = onset_to_death_ebola
+      epidist = onset_to_death_ebola
     ),
     ignore_attr = TRUE
   )

--- a/tests/testthat/test-estimate_severity.R
+++ b/tests/testthat/test-estimate_severity.R
@@ -17,7 +17,7 @@ poisson_threshold <- 100
 # get the corrected dataframe
 df_corrected <- known_outcomes(
   data = ebola1976,
-  epi_dist = onset_to_death_ebola
+  epidist = onset_to_death_ebola
 )
 
 # run estimate_severity
@@ -73,7 +73,7 @@ test_that("`estimate_rolling`: Basic expectations", {
   # get the corrected dataframe
   df_corrected <- known_outcomes(
     data = ebola1976,
-    epi_dist = onset_to_death_ebola
+    epidist = onset_to_death_ebola
   )
 
   # run estimate_severity
@@ -93,7 +93,7 @@ test_that("`estimate_rolling`: Messages and errors", {
   ebola1976$cases <- 0L
   df_corrected <- known_outcomes(
     data = ebola1976,
-    epi_dist = onset_to_death_ebola
+    epidist = onset_to_death_ebola
   )
 
   # expect an error because cases are 0

--- a/tests/testthat/test-estimate_static.R
+++ b/tests/testthat/test-estimate_static.R
@@ -18,7 +18,7 @@ scfr_naive <- estimate_static(data = ebola1976, correct_for_delays = FALSE)
 scfr_corrected <- estimate_static(
   data = ebola1976,
   correct_for_delays = TRUE,
-  epi_dist = onset_to_death_ebola
+  epidist = onset_to_death_ebola
 )
 
 # Basic expectations

--- a/tests/testthat/test-estimate_time_varying.R
+++ b/tests/testthat/test-estimate_time_varying.R
@@ -22,7 +22,7 @@ tvcfr_naive <- estimate_time_varying(
 # Calculate corrected time-varying
 tvcfr_corrected <- estimate_time_varying(
   ebola1976,
-  epi_dist = onset_to_death_ebola,
+  epidist = onset_to_death_ebola,
   smooth_inputs = FALSE,
   burn_in_value = 1,
   correct_for_delays = TRUE
@@ -85,7 +85,7 @@ tvcfr_naive_smoothed <- estimate_time_varying(
 # Calculate corrected time-varying
 tvcfr_corrected <- estimate_time_varying(
   ebola1976,
-  epi_dist = onset_to_death_ebola,
+  epidist = onset_to_death_ebola,
   smooth_inputs = FALSE,
   smoothing_window = 3,
   burn_in_value = 1,

--- a/tests/testthat/test-known_outcomes.R
+++ b/tests/testthat/test-known_outcomes.R
@@ -11,7 +11,7 @@ onset_to_death_ebola <- epiparameter::epidist_db(
 )
 
 df_known_outcomes <- known_outcomes(
-  data = ebola1976, epi_dist = onset_to_death_ebola
+  data = ebola1976, epidist = onset_to_death_ebola
 )
 
 test_that("`known_outcomes` basic functionality", {

--- a/vignettes/cfr.Rmd
+++ b/vignettes/cfr.Rmd
@@ -104,7 +104,7 @@ We use the function `estimate_static()` to calculate overall disease severity at
 estimate_static(
   data = ebola1976,
   correct_for_delays = TRUE,
-  epi_dist = onset_to_death_ebola
+  epidist = onset_to_death_ebola
 )
 ```
 
@@ -125,7 +125,7 @@ Here, we estimate reporting in the 1976 Ebola outbreak in the Congo, assuming th
 # estimate reporting with a baseline severity of 70%
 estimate_ascertainment(
   data = ebola1976,
-  epi_dist = onset_to_death_ebola,
+  epidist = onset_to_death_ebola,
   type = "static",
   severity_baseline = 0.7,
   correct_for_delays = TRUE

--- a/vignettes/data_from_incidence2.Rmd
+++ b/vignettes/data_from_incidence2.Rmd
@@ -107,7 +107,7 @@ Finally, we estimate the static case fatality rate while correcting for delays s
 # estimate static CFR as a sanity check
 estimate_static(
   ebola,
-  correct_for_delays = TRUE, epi_dist = onset_to_death_ebola
+  correct_for_delays = TRUE, epidist = onset_to_death_ebola
 )
 ```
 

--- a/vignettes/estimate_ascertainment.Rmd
+++ b/vignettes/estimate_ascertainment.Rmd
@@ -189,7 +189,7 @@ The other arguments are the same as those found in `estimate_time_varying()`.
 ```{r }
 df_reporting_static <- estimate_ascertainment(
   data = df_covid_uk_subset,
-  epi_dist = onset_to_death_covid,
+  epidist = onset_to_death_covid,
   type = "static",
   severity_baseline = 0.014,
   correct_for_delays = TRUE
@@ -199,7 +199,7 @@ df_reporting_static <- estimate_ascertainment(
 ```{r }
 df_reporting_varying <- estimate_ascertainment(
   data = df_covid_uk,
-  epi_dist = onset_to_death_covid,
+  epidist = onset_to_death_covid,
   type = "varying",
   severity_baseline = 0.014,
   smooth_inputs = TRUE,
@@ -270,7 +270,7 @@ df_reporting <- mutate(
   reporting = map(
     .x = data, .f = estimate_ascertainment,
     # arguments to function
-    epi_dist = onset_to_death_covid, type = "varying",
+    epidist = onset_to_death_covid, type = "varying",
     burn_in_value = 7, smooth_inputs = TRUE, correct_for_delays = TRUE
   )
 )

--- a/vignettes/estimate_static_severity.Rmd
+++ b/vignettes/estimate_static_severity.Rmd
@@ -169,7 +169,7 @@ The resulting data frame contains two new columns, "known_outcomes", for the num
 # calculate known outcomes
 df_known_outcomes_ebola <- known_outcomes(
   data = df_ebola_subset,
-  epi_dist = onset_to_death_ebola
+  epidist = onset_to_death_ebola
 )
 
 # visualise head of data frame
@@ -229,7 +229,7 @@ estimate_static(
 estimate_static(
   df_ebola_subset,
   correct_for_delays = TRUE,
-  epi_dist = onset_to_death_ebola
+  epidist = onset_to_death_ebola
 )
 ```
 
@@ -332,7 +332,7 @@ We use the same method and implementation as in the Ebola example to calculate t
 ```{r}
 df_known_outcomes_covid <- known_outcomes(
   data = df_covid_uk_subset,
-  epi_dist = onset_to_death_covid
+  epidist = onset_to_death_covid
 )
 ```
 
@@ -387,7 +387,7 @@ estimate_static(
 estimate_static(
   df_covid_uk_subset,
   correct_for_delays = TRUE,
-  epi_dist = onset_to_death_covid
+  epidist = onset_to_death_covid
 )
 ```
 

--- a/vignettes/estimate_time_varying_severity.Rmd
+++ b/vignettes/estimate_time_varying_severity.Rmd
@@ -178,7 +178,7 @@ We use the `estimate_time_varying()` function within the _cfr_ package to calcul
 # calculating the naive time-varying CFR
 df_covid_cfr_uk_naive <- estimate_time_varying(
   df_covid_uk_subset,
-  epi_dist = onset_to_death_covid,
+  epidist = onset_to_death_covid,
   smooth_inputs = TRUE,
   burn_in = 7,
   correct_for_delays = FALSE
@@ -187,7 +187,7 @@ df_covid_cfr_uk_naive <- estimate_time_varying(
 # calculating the corrected time-varying CFR
 df_covid_cfr_uk_corrected <- estimate_time_varying(
   df_covid_uk_subset,
-  epi_dist = onset_to_death_covid,
+  epidist = onset_to_death_covid,
   smooth_inputs = TRUE,
   burn_in = 7,
   correct_for_delays = TRUE
@@ -303,7 +303,7 @@ df_covid_cfr <- mutate(
   data = map(
     .x = data, .f = estimate_time_varying,
     # arguments to the function
-    epi_dist = onset_to_death_covid, smooth_inputs = TRUE,
+    epidist = onset_to_death_covid, smooth_inputs = TRUE,
     smoothing_window = 7, burn_in = 7
   )
 )


### PR DESCRIPTION
This PR fixes #63 by renaming the function argument `epi_dist` to `epidist`.
