### PR TITLE
Handle grouped incidence2 data and add input checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,7 +68,8 @@ Suggests:
     spelling,
     epiparameter,
     incidence2,
-    outbreaks
+    outbreaks,
+    data.table
 Remotes:
     epiverse-trace/epiparameter
 Config/testthat/edition: 3

--- a/R/estimate_ascertainment.R
+++ b/R/estimate_ascertainment.R
@@ -65,11 +65,19 @@ estimate_ascertainment <- function(data,
                                    smoothing_window = NULL,
                                    max_date = NULL) {
   # input checking
-  checkmate::assert_data_frame(data)
+  # expect rows more than burn in value
+  checkmate::assert_data_frame(data, min.cols = 3, min.rows = burn_in + 1)
+  # check that input `<data.frame>` has columns date, cases, and deaths
   checkmate::assert_names(
     colnames(data),
     must.include = c("date", "cases", "deaths")
   )
+  # check for any NAs among data
+  checkmate::assert_data_frame(
+    data[, c("date", "cases", "deaths")],
+    any.missing = FALSE
+  )
+
   checkmate::assert_number(
     severity_baseline,
     lower = 0.0, upper = 1.0, finite = TRUE

--- a/R/estimate_rolling.R
+++ b/R/estimate_rolling.R
@@ -47,11 +47,20 @@ cfr_rolling <- function(data,
                         poisson_threshold = 100) {
 
   # input checking
-  checkmate::assert_data_frame(data)
-  # check that input data.frame has columns date, cases, and deaths
+  # input checking
+  checkmate::assert_data_frame(
+    data,
+    min.rows = 1, min.cols = 3
+  )
+  # check that input `<data.frame>` has columns date, cases, and deaths
   checkmate::assert_names(
     colnames(data),
     must.include = c("date", "cases", "deaths")
+  )
+  # check for any NAs among data
+  checkmate::assert_data_frame(
+    data[, c("date", "cases", "deaths")],
+    any.missing = FALSE
   )
   # check that data$date is a date column
   checkmate::assert_date(data$date, any.missing = FALSE, all.missing = FALSE)

--- a/R/estimate_static.R
+++ b/R/estimate_static.R
@@ -100,11 +100,19 @@ cfr_static <- function(data,
                        epidist = NULL,
                        poisson_threshold = 100) {
   # input checking
-  checkmate::assert_data_frame(data)
+  checkmate::assert_data_frame(
+    data,
+    min.rows = 1, min.cols = 3
+  )
   # check that input `<data.frame>` has columns date, cases, and deaths
   checkmate::assert_names(
     colnames(data),
     must.include = c("date", "cases", "deaths")
+  )
+  # check for any NAs among data
+  checkmate::assert_data_frame(
+    data[, c("date", "cases", "deaths")],
+    any.missing = FALSE
   )
   # check that data$date is a date column
   checkmate::assert_date(data$date, any.missing = FALSE, all.missing = FALSE)

--- a/R/estimate_time_varying.R
+++ b/R/estimate_time_varying.R
@@ -103,11 +103,19 @@ cfr_time_varying <- function(data,
 
   # expect rows more than burn in value
   checkmate::assert_data_frame(data, min.cols = 3, min.rows = burn_in + 1)
+  # check that input `<data.frame>` has columns date, cases, and deaths
+  checkmate::assert_names(
+    colnames(data),
+    must.include = c("date", "cases", "deaths")
+  )
+  # check for any NAs among data
+  checkmate::assert_data_frame(
+    data[, c("date", "cases", "deaths")],
+    any.missing = FALSE
+  )
   checkmate::assert_number(smoothing_window, lower = 1, null.ok = TRUE)
 
   stopifnot(
-    "Case data must contain columns `cases` and `deaths`" =
-      (all(c("cases", "deaths") %in% colnames(data))),
     "`smoothing_window` must be an odd number greater than 0" =
       (smoothing_window %% 2 != 0)
   )

--- a/R/known_outcomes.R
+++ b/R/known_outcomes.R
@@ -48,6 +48,11 @@ known_outcomes <- function(data,
     names(data),
     must.include = c("cases", "date")
   )
+  # check for any NAs among data
+  checkmate::assert_data_frame(
+    data[, c("cases", "deaths")],
+    any.missing = FALSE
+  )
   checkmate::assert_class(epidist, "epidist")
 
   pmf_vals <- stats::density(

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -85,11 +85,9 @@ prepare_data.incidence2 <- function(data, cases_variable = "cases",
                                     ...) {
   # check for {incidence2} and error if not available
   if (!requireNamespace("incidence2", quietly = TRUE)) {
-    stop(
-      "Package 'incidence2' is required to prepare <incidence2> class data ",
-      "but is not installed."
-    )
+    stop("Install package 'incidence2' to prepare <incidence2> class data")
   }
+  # assume that installing incidence2 will also install data.table
 
   # assert that cases and deaths variable are different
   checkmate::assert_string(cases_variable)
@@ -124,7 +122,7 @@ prepare_data.incidence2 <- function(data, cases_variable = "cases",
   index <- index == cases_variable | index == deaths_variable
   data <- data[index, ]
 
-  formula <- reformulate(count_var_col, "...")
+  formula <- stats::reformulate(count_var_col, "...")
   # cast wide and fill any NAs per user input
   data <- data.table::dcast(
     data, formula,

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -103,7 +103,6 @@ prepare_data.incidence2 <- function(data, cases_variable = "cases",
   count_var_col <- incidence2::get_count_variable_name(data)
   count_col <- incidence2::get_count_value_name(data)
   dates_variable <- incidence2::get_date_index_name(data)
-  group_variables <- incidence2::get_group_names(data)
 
   stopifnot(
     "`cases_variable` and `deaths_variable` should be in \

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -9,11 +9,11 @@
 #' data.
 #'
 #' Currently, the only supported data format is `<incidence2>` from the
-#' \pkg{incidence2} package. See [incidence2::incidence()].
-#' This function does not currently support grouped `<incidence2>` data.
+#' \pkg{incidence2} package. See [incidence2::incidence()]. Grouped
+#' `<incidence2>` data are supported, see **Details**.
 #'
 #' @param data A `<data.frame>`-like object. Currently, only `<incidence2>`
-#' objects are supported.
+#' objects are supported. These may be grouped.
 #' @param cases_variable A string for the name of the cases variable in the
 #' "count_variable" column of `data`.
 #' @param deaths_variable A string for the name of the deaths variable in the
@@ -37,11 +37,14 @@
 #' [cfr_static()] on the data, as they cannot handle `NA`s.
 #' Setting `fill_NA = TRUE` resolves this issue, but must be a conscious choice.
 #'
+#' Passing a grouped `<incidence2>` object to `data` will result in the function
+#' respecting the grouping and returning grouping variables in separate columns.
+#'
 #' @return A `<data.frame>` suitable for disease severity estimation functions
 #' provided in \pkg{cfr}, with the columns "date", "cases", and "deaths".
 #'
-#' Note that groups in `<incidence2>` are not retained, and cases and deaths
-#' are summed by date.
+#' Additionally, for grouped `<incidence2>` data, columns representing the
+#' grouping variables will also be present.
 #'
 #' The result has a continuous sequence of dates between the start and end date
 #' of `data`; this is required if the data is to be passed to functions such as
@@ -69,6 +72,27 @@
 #' )
 #'
 #' tail(data)
+#'
+#' #### For grouped <incidence2> data ####
+#' # convert data to incidence2 object grouped by region
+#' covid_uk_incidence <- incidence2::incidence(
+#'   covid_uk,
+#'   date_index = "date",
+#'   counts = c("cases_new", "deaths_new"),
+#'   count_names_to = "count_variable",
+#'   groups = "region"
+#' )
+#'
+#' # View tail of prepared data
+#' data <- prepare_data(
+#'   covid_uk_incidence,
+#'   cases_variable = "cases_new",
+#'   deaths_variable = "deaths_new",
+#'   fill_NA = TRUE
+#' )
+#'
+#' tail(data)
+#'
 prepare_data <- function(data, ...) {
   UseMethod("prepare_data", data)
 }

--- a/man/prepare_data.Rd
+++ b/man/prepare_data.Rd
@@ -17,7 +17,7 @@ prepare_data(data, ...)
 }
 \arguments{
 \item{data}{A \verb{<data.frame>}-like object. Currently, only \verb{<incidence2>}
-objects are supported.}
+objects are supported. These may be grouped.}
 
 \item{...}{Currently unused. Passing extra arguments will throw a warning.}
 
@@ -36,8 +36,8 @@ data.}
 A \verb{<data.frame>} suitable for disease severity estimation functions
 provided in \pkg{cfr}, with the columns "date", "cases", and "deaths".
 
-Note that groups in \verb{<incidence2>} are not retained, and cases and deaths
-are summed by date.
+Additionally, for grouped \verb{<incidence2>} data, columns representing the
+grouping variables will also be present.
 
 The result has a continuous sequence of dates between the start and end date
 of \code{data}; this is required if the data is to be passed to functions such as
@@ -48,8 +48,8 @@ This S3 generic has methods for classes commonly used for epidemiological
 data.
 
 Currently, the only supported data format is \verb{<incidence2>} from the
-\pkg{incidence2} package. See \code{\link[incidence2:incidence]{incidence2::incidence()}}.
-This function does not currently support grouped \verb{<incidence2>} data.
+\pkg{incidence2} package. See \code{\link[incidence2:incidence]{incidence2::incidence()}}. Grouped
+\verb{<incidence2>} data are supported, see \strong{Details}.
 }
 \details{
 The method for \verb{<incidence2>} data can replace \code{NA}s in the case and death
@@ -63,6 +63,9 @@ of dates.
 Keeping \code{NA}s will cause downstream issues when calling functions such as
 \code{\link[=cfr_static]{cfr_static()}} on the data, as they cannot handle \code{NA}s.
 Setting \code{fill_NA = TRUE} resolves this issue, but must be a conscious choice.
+
+Passing a grouped \verb{<incidence2>} object to \code{data} will result in the function
+respecting the grouping and returning grouping variables in separate columns.
 }
 \examples{
 #### For <incidence2> data ####
@@ -86,4 +89,25 @@ data <- prepare_data(
 )
 
 tail(data)
+
+#### For grouped <incidence2> data ####
+# convert data to incidence2 object grouped by region
+covid_uk_incidence <- incidence2::incidence(
+  covid_uk,
+  date_index = "date",
+  counts = c("cases_new", "deaths_new"),
+  count_names_to = "count_variable",
+  groups = "region"
+)
+
+# View tail of prepared data
+data <- prepare_data(
+  covid_uk_incidence,
+  cases_variable = "cases_new",
+  deaths_variable = "deaths_new",
+  fill_NA = TRUE
+)
+
+tail(data)
+
 }

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -29,43 +29,9 @@ test_that("Prepare `<incidence2>` data, basic expectations", {
   expect_snapshot(
     tail(data)
   )
-
-  expect_error(
-    prepare_data(
-      data = incidence2::incidence(
-        incidence2::covidregionaldataUK,
-        date_index = "date",
-        counts = c("cases_new", "deaths_new"),
-        count_names_to = "count_variable",
-        groups = "region"
-      ),
-      cases_variable = "cases_new",
-      deaths_variable = "deaths_new",
-      fill_NA = TRUE
-    ),
-    regexp = "(Grouped `<incidence2>` objects are not supported.)"
-  )
 })
 
-# test for errors when NAs are present and `fill_NA` is FALSE
-test_that("Prepare data from `<incidence2>` errors on unfilled NAs", {
-  expect_error(
-    prepare_data(
-      data = incidence2::incidence(
-        incidence2::covidregionaldataUK,
-        date_index = "date",
-        counts = c("cases_new", "deaths_new"),
-        count_names_to = "count_variable"
-      ),
-      cases_variable = "cases_new",
-      deaths_variable = "deaths_new",
-      fill_NA = FALSE
-    ),
-    regexp = "(`NA`s present in the)*(count)*(Set `fill_NA = TRUE` to use 0s)"
-  )
-})
-
-test_that("`prepare_data(): Error for data.frame method", {
+test_that("Data preparation errors for data.frame method", {
   expect_error(
     prepare_data(
       as.data.frame(incidence2::covidregionaldataUK),
@@ -73,5 +39,42 @@ test_that("`prepare_data(): Error for data.frame method", {
       deaths_variable = "deaths_new"
     ),
     regexp = '(no applicable method)*(\\"data.frame\\")'
+  )
+})
+
+test_that("Prepare grouped `<incidence2>` data", {
+  grouping_variable <- "region"
+  data <- incidence2::incidence(
+    incidence2::covidregionaldataUK,
+    date_index = "date",
+    counts = c("cases_new", "deaths_new"),
+    count_names_to = "count_variable",
+    groups = grouping_variable
+  )
+
+  expect_no_condition(
+    prepare_data(
+      data,
+      cases_variable = "cases_new", deaths_variable = "deaths_new",
+      fill_NA = TRUE
+    )
+  )
+
+  data <- prepare_data(
+    data,
+    cases_variable = "cases_new", deaths_variable = "deaths_new",
+    fill_NA = TRUE
+  )
+
+  expect_s3_class(
+    data, "data.frame"
+  )
+  expect_named(
+    data,
+    expected = c(
+      "date", "cases", "deaths",
+      grouping_variable
+    ),
+    ignore.order = TRUE
   )
 })


### PR DESCRIPTION
This PR adds support for grouped `incidence2` data and fixes #52 thanks to code from @TimTaylor.

This PR also adds some input checking for data.frames passed to `cfr_x()` functions.