### PR TITLE
Remove duplicate entry on website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,7 +5,6 @@ articles:
 - title: Package vignettes
   navbar: Package vignettes
   contents:
-  - delay_distributions
   - estimate_static_severity
   - estimate_time_varying_severity
   - estimate_ascertainment


### PR DESCRIPTION
This PR removes a duplicate entry of the delay distributions vignette on the website