### PR TITLE
Remove time-varying ascertainment

### DIFF
--- a/man/estimate_ascertainment.Rd
+++ b/man/estimate_ascertainment.Rd
@@ -4,14 +4,7 @@
 \alias{estimate_ascertainment}
 \title{Estimate the ascertainment ratio of a disease}
 \usage{
-estimate_ascertainment(
-  data,
-  severity_baseline,
-  delay_density = NULL,
-  type = c("static", "varying"),
-  burn_in = 7,
-  smoothing_window = NULL
-)
+estimate_ascertainment(data, severity_baseline, delay_density = NULL)
 }
 \arguments{
 \item{data}{A \verb{<data.frame>} containing the outbreak data. A daily time
@@ -39,29 +32,6 @@ May be \code{NULL}, for no delay correction, or a function that returns the
 density function of a distribution to evaluate
 density at user-specified values, e.g.
 \code{function(x) stats::dgamma(x = x, shape = 5, scale = 1)}.}
-
-\item{type}{A string, either \code{"static"} or \code{"varying"} which determines
-whether \code{\link[=cfr_static]{cfr_static()}} or \code{\link[=cfr_time_varying]{cfr_time_varying()}} is used to calculate
-the resulting ascertainment ratio. Defaults to \code{"static"} if this argument is
-missing.}
-
-\item{burn_in}{A single integer-like value for the number of time-points
-(typically days) to disregard at the start of the time-series, if a burn-in
-period is desired.
-
-Defaults to 7, which is a sensible default value that disregards the first
-week of cases and deaths, assuming daily data.
-
-To consider all case data including the start of the time-series, set this
-argument to 0.}
-
-\item{smoothing_window}{An \emph{odd} number determining the smoothing window size
-to use when smoothing the case and death time-series, using a rolling median
-procedure (as the \code{k} argument to \code{\link[stats:runmed]{stats::runmed()}}) before calculating the
-time-varying severity.
-
-The default behaviour is to apply no smoothing. The minimum value of this
-argument is 1.}
 }
 \value{
 A \verb{<data.frame>} containing the maximum likelihood estimate estimate
@@ -94,9 +64,7 @@ data <- df_covid_uk[df_covid_uk$date <= "2020-06-30", ]
 estimate_ascertainment(
   data = data,
   delay_density = function(x) dlnorm(x, meanlog = 2.577, sdlog = 0.440),
-  type = "varying",
-  severity_baseline = 0.014,
-  burn_in = 7L
+  severity_baseline = 0.014
 )
 
 }

--- a/tests/testthat/_snaps/estimate_ascertainment.md
+++ b/tests/testthat/_snaps/estimate_ascertainment.md
@@ -14,44 +14,12 @@
         ascertainment_mean ascertainment_low ascertainment_high
       1           0.729927               0.7          0.8313539
 
-# Smooth inputs for static ascertainment
-
-    Code
-      ascertainment_estimate
-    Output
-        ascertainment_mean ascertainment_low ascertainment_high
-      1           0.729927               0.7          0.8313539
-
-# Automatic burn-in for static ascertainment with delay correction
-
-    Code
-      ascertainment_estimate
-    Output
-        ascertainment_mean ascertainment_low ascertainment_high
-      1           0.729927               0.7          0.8313539
-
-# Automatic burn-in for static ascertainment, no delay correction
-
-    Code
-      ascertainment_estimate
-    Output
-        ascertainment_mean ascertainment_low ascertainment_high
-      1           0.732906         0.7162026          0.7599719
-
 # Static ascertainment from vignette
 
     Code
       estimate_ascertainment(data = covid_uk, delay_density = function(x) dlnorm(x,
-        meanlog = 2.577, sdlog = 0.44), type = "static", severity_baseline = 0.014)
+        meanlog = 2.577, sdlog = 0.44), severity_baseline = 0.014)
     Output
         ascertainment_mean ascertainment_low ascertainment_high
       1         0.06796117        0.06730769         0.06829268
-
-# Basic expectations for time-varying ascertainment
-
-    Code
-      ascertainment_estimate
-    Output
-        ascertainment_mean ascertainment_low ascertainment_high
-      1          0.2902857         0.2318857          0.3696896
 

--- a/tests/testthat/test-estimate_ascertainment.R
+++ b/tests/testthat/test-estimate_ascertainment.R
@@ -9,9 +9,7 @@ poisson_threshold <- 100
 test_that("Basic expectations for static ascertainment", {
   ascertainment_estimate <- estimate_ascertainment(
     data = ebola1976,
-    burn_in = 0,
-    severity_baseline = 0.7,
-    type = "static"
+    severity_baseline = 0.7
   )
 
   expect_s3_class(ascertainment_estimate, "data.frame")
@@ -42,107 +40,7 @@ test_that("Correct for delays for static ascertainment", {
   ascertainment_estimate <- estimate_ascertainment(
     data = ebola1976,
     delay_density = function(x) dgamma(x, shape = 2.40, scale = 3.33),
-    burn_in = 0,
-    severity_baseline = 0.7,
-    type = "static"
-  )
-
-  expect_s3_class(ascertainment_estimate, "data.frame")
-  expect_named(
-    ascertainment_estimate,
-    c("ascertainment_mean", "ascertainment_low", "ascertainment_high")
-  )
-  expect_true(
-    all(
-      apply(ascertainment_estimate, 2, function(x) x >= 0.0 && x <= 1.0)
-    )
-  )
-  expect_true(
-    all(
-      ascertainment_estimate$ascertainment_low <=
-        ascertainment_estimate$ascertainment_mean &&
-        ascertainment_estimate$ascertainment_mean <=
-          ascertainment_estimate$ascertainment_high
-    )
-  )
-  # snapshot test
-  expect_snapshot(
-    ascertainment_estimate
-  )
-})
-
-test_that("Smooth inputs for static ascertainment", {
-  ascertainment_estimate <- estimate_ascertainment(
-    data = ebola1976,
-    delay_density = function(x) dgamma(x, shape = 2.40, scale = 3.33),
-    burn_in = 0, smoothing_window = 7,
-    severity_baseline = 0.7,
-    type = "static"
-  )
-
-  expect_s3_class(ascertainment_estimate, "data.frame")
-  expect_named(
-    ascertainment_estimate,
-    c("ascertainment_mean", "ascertainment_low", "ascertainment_high")
-  )
-  expect_true(
-    all(
-      apply(ascertainment_estimate, 2, function(x) x >= 0.0 && x <= 1.0)
-    )
-  )
-  expect_true(
-    all(
-      ascertainment_estimate$ascertainment_low <=
-        ascertainment_estimate$ascertainment_mean &&
-        ascertainment_estimate$ascertainment_mean <=
-          ascertainment_estimate$ascertainment_high
-    )
-  )
-  # snapshot test
-  expect_snapshot(
-    ascertainment_estimate
-  )
-})
-
-test_that("Automatic burn-in for static ascertainment with delay correction", {
-  ascertainment_estimate <- estimate_ascertainment(
-    data = ebola1976,
-    delay_density = function(x) dgamma(x, shape = 2.40, scale = 3.33),
-    smoothing_window = 7,
-    severity_baseline = 0.7,
-    type = "static"
-  )
-
-  expect_s3_class(ascertainment_estimate, "data.frame")
-  expect_named(
-    ascertainment_estimate,
-    c("ascertainment_mean", "ascertainment_low", "ascertainment_high")
-  )
-  expect_true(
-    all(
-      apply(ascertainment_estimate, 2, function(x) x >= 0.0 && x <= 1.0)
-    )
-  )
-  expect_true(
-    all(
-      ascertainment_estimate$ascertainment_low <=
-        ascertainment_estimate$ascertainment_mean &&
-        ascertainment_estimate$ascertainment_mean <=
-          ascertainment_estimate$ascertainment_high
-    )
-  )
-  # snapshot test
-  expect_snapshot(
-    ascertainment_estimate
-  )
-})
-
-test_that("Automatic burn-in for static ascertainment, no delay correction", {
-  ascertainment_estimate <- estimate_ascertainment(
-    data = ebola1976,
-    smoothing_window = 7,
-    severity_baseline = 0.7,
-    type = "static"
+    severity_baseline = 0.7
   )
 
   expect_s3_class(ascertainment_estimate, "data.frame")
@@ -180,71 +78,26 @@ test_that("Static ascertainment from vignette", {
     estimate_ascertainment(
       data = covid_uk,
       delay_density = function(x) dlnorm(x, meanlog = 2.577, sdlog = 0.440),
-      type = "static",
       severity_baseline = 0.014
     )
   )
 })
 
-#### Time varying ascertainment ####
-
-test_that("Basic expectations for time-varying ascertainment", {
-  skip_if_not_installed("distributional") # use pkg to check functionality
-  # provide burn in as mean of lognormal distribution
-  distr_lnorm <- distributional::dist_lognormal(mu = 2.577, sigma = 0.440)
-  burn_in <- round(mean(distr_lnorm))
-
-  ascertainment_estimate <- estimate_ascertainment(
-    data = covid_uk,
-    delay_density = function(x) unlist(density(distr_lnorm, x)),
-    burn_in = burn_in,
-    severity_baseline = 0.02,
-    type = "varying"
-  )
-
-  expect_s3_class(ascertainment_estimate, "data.frame")
-  expect_identical(
-    nrow(ascertainment_estimate),
-    1L
-  )
-
-  expect_named(
-    ascertainment_estimate,
-    c("ascertainment_mean", "ascertainment_low", "ascertainment_high")
-  )
-  expect_true(
-    all(
-      apply(ascertainment_estimate, 2, function(x) x >= 0.0 && x <= 1.0)
-    )
-  )
-  expect_true(
-    all(
-      ascertainment_estimate$ascertainment_low <=
-        ascertainment_estimate$ascertainment_mean &&
-        ascertainment_estimate$ascertainment_mean <=
-          ascertainment_estimate$ascertainment_high
-    )
-  )
-  # snapshot test
-  expect_snapshot(
-    ascertainment_estimate
-  )
-})
-
 # test for a warning from ascertainment ratios > 1.0
+# artificially set baseline severity to be very high
+# this is more an issue for infections with lower reporting such as Covid-19
 test_that("Ascertainment > 1.0 throws a warning", {
   expect_warning(
     estimate_ascertainment(
       data = ebola1976,
       delay_density = function(x) dgamma(x, shape = 2.40, scale = 3.33),
-      severity_baseline = 0.7,
-      type = "varying"
+      severity_baseline = 0.9
     ),
     regexp = "Ascertainment ratios > 1.0 detected, setting these values to 1.0"
   )
 })
 
-# Test statistical correctness of ascertainment
+#### Test statistical correctness of ascertainment ####
 test_that("Ascertainment is statistically correct", {
   # simple assumptions
   # assume 1% true CFR
@@ -262,23 +115,8 @@ test_that("Ascertainment is statistically correct", {
   expect_identical(
     estimate_ascertainment(
       data,
-      severity_baseline = 0.01,
-      type = "static"
+      severity_baseline = 0.01
     )$ascertainment_mean,
     severity_baseline / (daily_deaths / daily_cases)
-  )
-
-  # exepect estimate is 0.5
-  # suppress warnings about ratios > 1.0 being replaced
-  suppressWarnings(
-    expect_identical(
-      estimate_ascertainment(
-        data,
-        severity_baseline = 0.01,
-        burn_in = 7,
-        type = "varying"
-      )$ascertainment_mean,
-      severity_baseline / (daily_deaths / daily_cases)
-    )
   )
 })

--- a/vignettes/cfr.Rmd
+++ b/vignettes/cfr.Rmd
@@ -123,7 +123,6 @@ We use the onset-to-death distribution from @barry2018.
 estimate_ascertainment(
   data = ebola1976,
   delay_density = function(x) dgamma(x, shape = 2.40, scale = 3.33),
-  type = "static",
   severity_baseline = 0.7
 )
 ```

--- a/vignettes/delay_distributions.Rmd
+++ b/vignettes/delay_distributions.Rmd
@@ -51,7 +51,7 @@ To correct for reporting delays in disease severity estimation, we are primarily
 
 We refer to the _R functions providing_ both the PDF and PMF as the _density_ of the distribution.
 
-The delay distribution density must be passed to functions such as `cfr_static()` or `cfr_time_varying()` via the `delay_density` argument. This can be represented in pseudo-code as
+The delay distribution density must be passed to functions such as `cfr_static()`, `cfr_time_varying()`, or `estimate_ascertainment()` via the `delay_density` argument. This can be represented in pseudo-code as
 
 ```
 cfr_*(data, delay_density = <DENSITY_FUNCTION>)

--- a/vignettes/estimate_ascertainment.Rmd
+++ b/vignettes/estimate_ascertainment.Rmd
@@ -30,7 +30,7 @@ The ascertainment of cases during an outbreak is influenced by a multiple factor
 
 The ascertainment ratio is calculated as the disease severity calculated from the data, divided by the "known" disease severity known or assumed from our best knowledge of the pathology of the disease.
 
-`estimate_ascertainment()` uses `cfr_static()` or `cfr_time_varying()` internally to estimate the delay-adjusted severity of the disease.
+`estimate_ascertainment()` uses `cfr_static()` internally to estimate the delay-adjusted severity of the disease.
 
 ::: {.alert .alert-warning}
 New to calculating disease severity using _cfr_? You might want to see the ["Get started" vignette first](cfr.html).
@@ -63,10 +63,6 @@ library(forcats)
 library(ggplot2)
 ```
 
-::: {.alert .alert-info}
-See the vignettes on [estimating a static measure of disease severity](cfr_static_severity.html) and [estimating a time-varying measure of disease severity](cfr_time_varying_severity.html), respectively, for more details on each of these functions.
-:::
-
 ## Ascertainment for the Covid-19 pandemic in the U.K.
 
 This example shows ascertainment ratio estimation using _cfr_ and data from the Covid-19 pandemic in the United Kingdom.
@@ -98,7 +94,7 @@ See the [vignette on delay distributions](delay_distribution.html) for more on u
 
 ### Estimating the proportion of cases that have been ascertained
 
-We use the `estimate_ascertainment()` function to calculate the time-varying CFR for the Covid-19 pandemic in the U.K.
+We use the `estimate_ascertainment()` function to calculate the static CFR (internally), and the overall ascertainment for the Covid-19 pandemic in the U.K.
 
 We assume that the "true" CFR of Covid-19 is 0.014 (i.e. 1.4%) [@verity2020].
 Future plans for this package include ability to incorporate uncertainty in CFR estimates when calculating under-ascertainment.
@@ -115,25 +111,9 @@ Furthermore, by ignoring uncertainty in this estimate, the ascertainment ratio i
 estimate_ascertainment(
   data = df_covid_uk,
   delay_density = function(x) dlnorm(x, meanlog = 2.577, sdlog = 0.440),
-  type = "static",
   severity_baseline = 0.014
 )
 ```
-
-```{r }
-# time varying ascertainment on data
-estimate_ascertainment(
-  data = df_covid_uk,
-  delay_density = function(x) dlnorm(x, meanlog = 2.577, sdlog = 0.440),
-  type = "varying",
-  severity_baseline = 0.014,
-  burn_in = 7
-)
-```
-
-**Note** that `estimate_ascertainment()` allows a `burn_in` argument that is passed to `cfr_time_varying()`.
-The `burn_in` time is used to determine how many days at the start of the outbreak are excluded from the CFR calculation, potentially due to poor data quality at the beginning of an outbreak.
-The default value is 7, which ignores the first week of data.
 
 ## Ascertainment in countries with large early Covid-19 pandemics
 
@@ -165,9 +145,8 @@ df_reporting <- mutate(
   reporting = map(
     .x = data, .f = estimate_ascertainment,
     # arguments to function
-    delay_density = delay_density, type = "varying",
     severity_baseline = 0.014,
-    burn_in = 7
+    delay_density = delay_density
   )
 )
 


### PR DESCRIPTION
This PR removes time-varying ascertainment as per https://github.com/epiverse-trace/cfr/pull/103#issuecomment-1813330157.