### PR TITLE
Clarify use of continuous distributions

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -40,7 +40,6 @@ com
 covidregionaldata
 dbinom
 dfrac
-discretised
 distcrete
 doi
 ebola

--- a/vignettes/cfr.Rmd
+++ b/vignettes/cfr.Rmd
@@ -79,7 +79,7 @@ We obtain the disease's onset-to-death distribution from a more recent Ebola out
 The onset-to-death distribution is considered to be Gamma distributed, with a shape $k$ = 2.40 and a scale of $\theta$ = 3.33.
 
 ::: {.alert .alert-warning}
-**Note that** while we use a continuous distribution here, it is more appropriate to use a discretised distribution instead as we are working with daily data.
+**Note that** while we use a continuous distribution here, it is more appropriate to use a discrete distribution instead as we are working with daily data.
 
 **Note also** that we use the central estimates for each distribution parameter, and by ignoring uncertainty in these parameters the uncertainty in the resulting CFR is likely to be underestimated. 
 :::

--- a/vignettes/delay_distributions.Rmd
+++ b/vignettes/delay_distributions.Rmd
@@ -124,8 +124,8 @@ cfr_static(
 
 ### Using _distcrete_
 
-The _distcrete_ package provides support for discretised distributions.
-Here, we show an example for the discretised Gamma distribution.
+The _distcrete_ package provides support for discrete distributions.
+Here, we show an example for the discrete Gamma distribution.
 **Note that** the density function for `<distcrete>` objects is encapsulated, and can be passed directly to the `delay_density` argument.
 
 ```{r}
@@ -142,8 +142,16 @@ cfr_static(
 ```
 
 ::: {.alert .alert-warning}
-**Note that** discretised distributions are the more appropriate choice to be passed to `cfr_*()`, as we are usually working with daily case and death data.
-We do use continuous distributions in many examples as we do not expect this difference to bias the estimates excessively.
+## Using continuous and discrete distributions
+
+**Note that** discrete distributions are the more appropriate choice to be passed to `cfr_*()`, as we are usually working with daily case and death data.
+
+We do use continuous distributions in many examples as onset-to-death delays are typically long with large variance.
+Evaluating the probability distribution function of such distributions at discrete points (here, days) is similar to evaluating the probability mass function of the equivalent discrete distribution.
+
+However, note that this assumption may not be appropriate for more strongly peaked distributions, i.e., where onset-to-death is strongly peaked with a low variance, as the difference between the PDF and PMF is likely to be larger on average (than for a more spread out distribution).
+
+Further, _cfr_ functions tally estimated death counts (calculated by convolving cases and densities), so that any underestimates due to the PDF-PMF discrepancy at one end of the distribution help to cancel out overestimates at the end of the distribution.
 :::
 
 ## Links to _epiparameter_

--- a/vignettes/estimate_ascertainment.Rmd
+++ b/vignettes/estimate_ascertainment.Rmd
@@ -86,8 +86,8 @@ tail(df_covid_uk)
 We obtain the appropriate distribution reported in @linton2020; this is a log-normal distribution with $\mu$ = 2.577 and $\sigma$ = 0.440.
 
 ::: {.alert .alert-warning}
-**Note that** @linton2020 fitted a discretised lognormal distribution --- but we use a continuous distribution here as we do not expect this difference to bias the estimates excessively.
-See the [vignette on delay distributions](delay_distributions.html) for more on using discretised distributions with _cfr_.
+**Note that** @linton2020 fitted a discrete lognormal distribution --- but we use a continuous distribution here.
+See the [vignette on delay distributions](delay_distributions.html) for more on when using a continuous instead of discrete distribution is acceptable, and on using discrete distributions with _cfr_.
 
 **Note that** we use the central estimates for each distribution parameter, and by ignoring uncertainty in these parameters the uncertainty in the resulting CFR is likely to be underestimated. 
 :::

--- a/vignettes/estimate_static_severity.Rmd
+++ b/vignettes/estimate_static_severity.Rmd
@@ -76,8 +76,8 @@ We retrieve the parameters of the distribution of durations (also called delays)
 This is a Gamma distribution with shape $k$ = 2.40 and scale $\theta$ = 3.33.
 
 ::: {.alert .alert-warning}
-**Note that** while we shall use a continuous distribution here as we do not expect this difference to bias the estimates excessively, it is more appropriate to use a discretised distribution instead as we are working with daily data.
-See the [vignette on delay distributions](delay_distributions.html) for more on using discretised distributions with _cfr_.
+**Note that** while we shall use a continuous distribution here, it is more appropriate to use a discrete distribution instead as we are working with daily data.
+See the [vignette on delay distributions](delay_distributions.html) for more on when using a continuous instead of discrete distribution is acceptable, and on using discrete distributions with _cfr_.
 
 **Note also** that we use the central estimates for each distribution parameter, and by ignoring uncertainty in these parameters the uncertainty in the resulting CFR is likely to be underestimated. 
 :::
@@ -152,7 +152,7 @@ head(df_covid_uk)
 We retrieve the appropriate distribution for Covid-19 from @linton2020; this is a lognormal distribution with $\mu$ = 2.577 and $\sigma$ = 0.440.
 
 ::: {.alert .alert-warning}
-**Note that** @linton2020 fitted a discretised lognormal distribution and we use a continuous distribution, and that we are ignoring uncertainty in the distribution parameters and likely under-estimating uncertainty in the CFR.
+**Note that** @linton2020 fitted a discrete lognormal distribution and we use a continuous distribution, and that we are ignoring uncertainty in the distribution parameters and likely under-estimating uncertainty in the CFR.
 :::
 
 ### Estimating the naive and corrected CFR

--- a/vignettes/estimate_time_varying_severity.Rmd
+++ b/vignettes/estimate_time_varying_severity.Rmd
@@ -95,8 +95,8 @@ head(df_covid_uk)
 We retrieve the appropriate distribution of the duration between symptom onset and deaths reported in @linton2020; this is a lognormal distribution with $\mu$ = 2.577 and $\sigma$ = 0.440.
 
 ::: {.alert .alert-warning}
-@linton2020 fitted a discretised lognormal distribution --- but we use a continuous distribution here as we do not expect this difference to bias the estimates excessively.
-See the [vignette on delay distributions](delay_distributions.html) for more on using discretised distributions with _cfr_.
+@linton2020 fitted a discrete lognormal distribution --- but we use a continuous distribution here.
+See the [vignette on delay distributions](delay_distributions.html) for more on when using a continuous instead of discrete distribution is acceptable, and on using discrete distributions with _cfr_.
 
 **Note also** that we use the central estimates for each distribution parameter, and by ignoring uncertainty in these parameters the uncertainty in the resulting CFR is likely to be underestimated. 
 :::


### PR DESCRIPTION
This PR fixes #115 by upgrading a note adapted from @adamkucharski  in the delay distributions vignette to a section on when it is acceptable to use continuous distributions in place of discrete distributions. All other vignettes now point to the delay distributions vignette when clarifying this point.