### PR TITLE
Fix argument name in `cfr_time_varying()` documentation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
-# -----------------------------------------------------------
-# CITATION file created with {cffr} R package, v0.5.0
+# --------------------------------------------
+# CITATION file created with {cffr} R package
 # See also: https://docs.ropensci.org/cffr/
-# -----------------------------------------------------------
+# --------------------------------------------
  
 cff-version: 1.2.0
 message: 'To cite package "cfr" in publications use:'
@@ -10,7 +10,7 @@ license: MIT
 title: 'cfr: Estimate Disease Severity and Case Ascertainment'
 version: 0.1.0.9000
 abstract: Estimate the severity of a disease and ascertainment of cases, as discussed
-  in Nishiura et al. (2009) <doi:10.1371/journal.pone.0006852>.
+  in Nishiura et al. (2009) <https://doi.org/10.1371/journal.pone.0006852>.
 authors:
 - family-names: Gupte
   given-names: Pratik R.
@@ -41,6 +41,7 @@ keywords:
 - outbreak-analysis
 - r
 - r-package
+- sdg-3
 references:
 - type: software
   title: 'R: A Language and Environment for Statistical Computing'
@@ -48,11 +49,10 @@ references:
   url: https://www.R-project.org/
   authors:
   - name: R Core Team
-  location:
-    name: Vienna, Austria
-  year: '2024'
   institution:
     name: R Foundation for Statistical Computing
+    address: Vienna, Austria
+  year: '2024'
   version: '>= 3.5.0'
 - type: software
   title: checkmate
@@ -72,11 +72,10 @@ references:
   notes: Imports
   authors:
   - name: R Core Team
-  location:
-    name: Vienna, Austria
-  year: '2024'
   institution:
     name: R Foundation for Statistical Computing
+    address: Vienna, Austria
+  year: '2024'
 - type: software
   title: bookdown
   abstract: 'bookdown: Authoring Books and Technical Documents with R Markdown'
@@ -215,6 +214,10 @@ references:
   - family-names: Dunnington
     given-names: Dewey
     orcid: https://orcid.org/0000-0002-9415-4582
+  - family-names: Brand
+    given-names: Teun
+    name-particle: van den
+    orcid: https://orcid.org/0000-0002-9335-7468
   year: '2024'
 - type: software
   title: incidence2
@@ -319,7 +322,7 @@ references:
   title: spelling
   abstract: 'spelling: Tools for Spell Checking in R'
   notes: Suggests
-  url: https://docs.ropensci.org/spelling/
+  url: https://ropensci.r-universe.dev/spelling
   repository: https://CRAN.R-project.org/package=spelling
   authors:
   - family-names: Ooms
@@ -358,3 +361,4 @@ references:
   - family-names: Girlich
     given-names: Maximilian
   year: '2024'
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,4 +57,4 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/R/cfr_time_varying.R
+++ b/R/cfr_time_varying.R
@@ -50,9 +50,9 @@
 #'
 #' The epidemiological delay distribution passed to `delay_density` is used to
 #' obtain a probability mass function parameterised by time; i.e. \eqn{f(t)}
-#' which gives the probability of the binary outcome of a case (usually, survival or death) being known by
-#' time \eqn{t}. The delay distribution is parameterised with disease-specific parameters before it is
-#' supplied here.
+#' which gives the probability of the binary outcome of a case (survival or
+#' death) being known by time \eqn{t}. The delay distribution is parameterised
+#' with disease-specific parameters before it is supplied here.
 #'
 #' **Note** that the function arguments `burn_in` and `smoothing_window` are not
 #' explicitly used in this calculation. `burn_in` controls how many estimates at

--- a/R/cfr_time_varying.R
+++ b/R/cfr_time_varying.R
@@ -50,8 +50,8 @@
 #'
 #' The epidemiological delay distribution passed to `delay_density` is used to
 #' obtain a probability mass function parameterised by time; i.e. \eqn{f(t)}
-#' which gives the probability a case has a known outcomes (usually, death) at
-#' time \eqn{t}, parameterised with disease-specific parameters before it is
+#' which gives the probability of the binary outcome of a case (usually, survival or death) being known by
+#' time \eqn{t}. The delay distribution is parameterised with disease-specific parameters before it is
 #' supplied here.
 #'
 #' **Note** that the function arguments `burn_in` and `smoothing_window` are not

--- a/R/cfr_time_varying.R
+++ b/R/cfr_time_varying.R
@@ -48,11 +48,11 @@
 #' for each \eqn{t}, where \eqn{\theta} represents the severity measure of
 #' interest.
 #'
-#' The epidemiological delay distribution passed to `epidist` is used to obtain
-#' a probability mass function parameterised by time; i.e. \eqn{f(t)} which
-#' gives the probability a case has a known outcomes (usually, death) at time
-#' \eqn{t}, parameterised with disease-specific parameters before it is supplied
-#' here.
+#' The epidemiological delay distribution passed to `delay_density` is used to
+#' obtain a probability mass function parameterised by time; i.e. \eqn{f(t)}
+#' which gives the probability a case has a known outcomes (usually, death) at
+#' time \eqn{t}, parameterised with disease-specific parameters before it is
+#' supplied here.
 #'
 #' **Note** that the function arguments `burn_in` and `smoothing_window` are not
 #' explicitly used in this calculation. `burn_in` controls how many estimates at

--- a/man/cfr_time_varying.Rd
+++ b/man/cfr_time_varying.Rd
@@ -80,11 +80,11 @@ We use maximum likelihood estimation to determine the value of \eqn{\theta_t}
 for each \eqn{t}, where \eqn{\theta} represents the severity measure of
 interest.
 
-The epidemiological delay distribution passed to \code{epidist} is used to obtain
-a probability mass function parameterised by time; i.e. \eqn{f(t)} which
-gives the probability a case has a known outcomes (usually, death) at time
-\eqn{t}, parameterised with disease-specific parameters before it is supplied
-here.
+The epidemiological delay distribution passed to \code{delay_density} is used to
+obtain a probability mass function parameterised by time; i.e. \eqn{f(t)}
+which gives the probability a case has a known outcomes (usually, death) at
+time \eqn{t}, parameterised with disease-specific parameters before it is
+supplied here.
 
 \strong{Note} that the function arguments \code{burn_in} and \code{smoothing_window} are not
 explicitly used in this calculation. \code{burn_in} controls how many estimates at


### PR DESCRIPTION
This PR fixes a possible typo in the documentation of `cfr_time_varying()` which references what is maybe a previous version of the `delay_density` argument, `epidist`. 

- [x] I have read the CONTRIBUTING guidelines
- [ ] A new item has been added to `NEWS.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Checks have been run locally and pass

This PR doesn't not contain any (functional) user-facing or breaking changes.
