### PR TITLE
Fix pkgdown YAML

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,7 @@
 url: https://epiverse-trace.github.io/cfr/
 template:
   package: epiversetheme
+  bootstrap: 5
 articles:
 - title: Package vignettes
   navbar: Package vignettes


### PR DESCRIPTION
This PR adds a manual specification of the Bootstrap version (5) in the pkgdown YAML due to a breaking change in {pkgdown}.