### PR TITLE
Use internal checking function to reduce duplication

### DIFF
--- a/R/cfr_rolling.R
+++ b/R/cfr_rolling.R
@@ -63,32 +63,7 @@ cfr_rolling <- function(data,
     " the course of the outbreak."
   )
   # input checking
-  checkmate::assert_data_frame(
-    data,
-    min.rows = 1, min.cols = 3
-  )
-  # check that input `<data.frame>` has columns date, cases, and deaths
-  checkmate::assert_names(
-    colnames(data),
-    must.include = c("date", "cases", "deaths")
-  )
-  # check for any NAs among data
-  checkmate::assert_data_frame(
-    data[, c("date", "cases", "deaths")],
-    types = c("Date", "integerish"),
-    any.missing = FALSE
-  )
-  # check that data$date is a date column
-  checkmate::assert_date(data$date, any.missing = FALSE, all.missing = FALSE)
-  # check for excessive missing date and throw an error
-  # also check delay_density
-  stopifnot(
-    "Input data must have sequential dates with none missing or duplicated" =
-      identical(unique(as.numeric(diff(data$date))), 1) # use numeric 1
-    # this solution works when df$date is `Date`
-    # this may need more thought for dates that are integers, POSIXct,
-    # or other units; consider the units package
-  )
+  .check_input_data(data)
   checkmate::assert_count(poisson_threshold, positive = TRUE)
 
   # NOTE: delay_density is checked in estimate_outcomes() if passed and not NULL
@@ -97,8 +72,6 @@ cfr_rolling <- function(data,
   cumulative_cases <- cumsum(data$cases)
   cumulative_deaths <- cumsum(data$deaths)
 
-  # Check cumulative sums for count type
-  checkmate::assert_integerish(cumulative_cases, lower = 0)
   # use assert_number to set upper limit at total_cases
   checkmate::assert_integerish(
     cumulative_deaths,

--- a/R/cfr_static.R
+++ b/R/cfr_static.R
@@ -124,33 +124,7 @@
 cfr_static <- function(data,
                        delay_density = NULL,
                        poisson_threshold = 100) {
-  # input checking
-  checkmate::assert_data_frame(
-    data,
-    min.rows = 1, min.cols = 3
-  )
-  # check that input `<data.frame>` has columns date, cases, and deaths
-  checkmate::assert_names(
-    colnames(data),
-    must.include = c("date", "cases", "deaths")
-  )
-  # check for any NAs among data
-  checkmate::assert_data_frame(
-    data[, c("date", "cases", "deaths")],
-    types = c("Date", "integerish"),
-    any.missing = FALSE
-  )
-  # check that data$date is a date column
-  checkmate::assert_date(data$date, any.missing = FALSE, all.missing = FALSE)
-
-  # check for excessive missing date and throw an error
-  stopifnot(
-    "Input data must have sequential dates with none missing or duplicated" =
-      identical(unique(as.numeric(diff(data$date))), 1) # use numeric 1
-    # this solution works when df$date is `Date`
-    # this may need more thought for dates that are integers, POSIXct,
-    # or other units; consider the units package
-  )
+  .check_input_data(data)
   checkmate::assert_count(poisson_threshold, positive = TRUE)
 
   # NOTE: delay_density is checked in estimate_outcomes() if passed and not NULL
@@ -160,8 +134,6 @@ cfr_static <- function(data,
   total_cases <- sum(data$cases, na.rm = TRUE)
   total_deaths <- sum(data$deaths, na.rm = TRUE)
 
-  # Add input checking for total cases and deaths
-  checkmate::assert_count(total_cases)
   # use assert_number to set upper limit at total_cases
   checkmate::assert_number(total_deaths, upper = total_cases, lower = 0)
 

--- a/R/cfr_time_varying.R
+++ b/R/cfr_time_varying.R
@@ -101,26 +101,10 @@ cfr_time_varying <- function(data,
   # input checking
   # zero count allowed to include all data
   checkmate::assert_count(burn_in)
-
-  # expect rows more than burn in value
-  checkmate::assert_data_frame(data, min.cols = 3, min.rows = burn_in + 1)
-  # check that input `<data.frame>` has columns date, cases, and deaths
-  checkmate::assert_names(
-    colnames(data),
-    must.include = c("date", "cases", "deaths")
-  )
-  # check for any NAs among data
-  checkmate::assert_data_frame(
-    data[, c("date", "cases", "deaths")],
-    any.missing = FALSE
-  )
-  # check that data$date is a date column
-  checkmate::assert_date(data$date, any.missing = FALSE, all.missing = FALSE)
   checkmate::assert_count(smoothing_window, null.ok = TRUE)
+  .check_input_data(data)
 
   stopifnot(
-    "Input data must have sequential dates with none missing or duplicated" =
-      identical(unique(as.numeric(diff(data$date))), 1), # use numeric 1
     "`smoothing_window` must be an odd number greater than 0" =
       (smoothing_window %% 2 != 0),
     "`delay_density` must be a function with a single required argument,

--- a/R/check_input_data.R
+++ b/R/check_input_data.R
@@ -1,0 +1,32 @@
+.check_input_data <- function(data) {
+
+  checkmate::assert_data_frame(
+    data,
+    min.rows = 1, min.cols = 3
+  )
+  # check that input `<data.frame>` has columns date, cases, and deaths
+  checkmate::assert_names(
+    colnames(data),
+    must.include = c("date", "cases", "deaths")
+  )
+  # check for any NAs among data
+  checkmate::assert_data_frame(
+    data[, c("date", "cases", "deaths")],
+    types = c("Date", "integerish"),
+    any.missing = FALSE
+  )
+  # check that data$date is a date column
+  checkmate::assert_date(data$date, any.missing = FALSE, all.missing = FALSE)
+
+  # Check count types
+  checkmate::assert_integerish(data$cases, lower = 0)
+  checkmate::assert_integerish(data$deaths, lower = 0)
+
+  stopifnot(
+    "Input data must have sequential dates with none missing or duplicated" =
+      identical(unique(as.numeric(diff(data$date))), 1) # use numeric 1
+    # this solution works when df$date is `Date`
+    # this may need more thought for dates that are integers, POSIXct,
+    # or other units; consider the units package
+  )
+}


### PR DESCRIPTION
- First commit creates an internal function containing checks common to all the `cfr_()` function
- Second commit uses a collection so that the input data is completely validated in one go, and an error message with all the issues is returned. This prevents the user from having to try and error multiple times, with a different error message each time.