### PR TITLE
Update `.estimate_severity.Rd`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,4 +57,4 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/man/dot-estimate_severity.Rd
+++ b/man/dot-estimate_severity.Rd
@@ -49,9 +49,8 @@ approximated by a Poisson likelihood for large samples.
 \item When any two of \code{total_cases}, \code{total_deaths}, or \code{total_outcomes} are 0,
 the estimate and confidence intervals cannot be calculated and the output
 \verb{<data.frame>} contains only \code{NA}s.
-\item When \code{total_outcomes <= total_deaths}, the confidence intervals cannot be
-reliably calculated and are returned as \code{NA}. The severity estimate is returned
-as \code{0.999}.
+\item When \code{total_outcomes <= total_deaths}, estimate and confidence intervals
+cannot be reliably calculated and are returned as \code{NA}.
 }
 }
 }


### PR DESCRIPTION
This PR ensures that all function documentation in the `man/` folder is up-to-date with the Roxygen function documentation by running `devtools::document()`. It seems the function documentation in `.estimate_severity()` was out of sync since PR #153.