### PR TITLE
Fix difftime bug for CRAN

### DIFF
--- a/R/cfr_rolling.R
+++ b/R/cfr_rolling.R
@@ -84,7 +84,7 @@ cfr_rolling <- function(data,
   # also check delay_density
   stopifnot(
     "Input data must have sequential dates with none missing or duplicated" =
-      identical(unique(as.numeric(diff(data$date))), 1) # use numeric 1, not integer
+      identical(unique(as.numeric(diff(data$date))), 1) # use numeric 1
     # this solution works when df$date is `Date`
     # this may need more thought for dates that are integers, POSIXct,
     # or other units; consider the units package

--- a/R/cfr_rolling.R
+++ b/R/cfr_rolling.R
@@ -84,7 +84,7 @@ cfr_rolling <- function(data,
   # also check delay_density
   stopifnot(
     "Input data must have sequential dates with none missing or duplicated" =
-      identical(unique(diff(data$date)), 1) # use numeric 1, not integer
+      identical(unique(as.numeric(diff(data$date))), 1) # use numeric 1, not integer
     # this solution works when df$date is `Date`
     # this may need more thought for dates that are integers, POSIXct,
     # or other units; consider the units package

--- a/R/cfr_static.R
+++ b/R/cfr_static.R
@@ -146,7 +146,7 @@ cfr_static <- function(data,
   # check for excessive missing date and throw an error
   stopifnot(
     "Input data must have sequential dates with none missing or duplicated" =
-      identical(unique(diff(data$date)), 1) # use numeric 1, not integer
+      identical(unique(as.numeric(diff(data$date))), 1) # use numeric 1, not integer
     # this solution works when df$date is `Date`
     # this may need more thought for dates that are integers, POSIXct,
     # or other units; consider the units package

--- a/R/cfr_static.R
+++ b/R/cfr_static.R
@@ -146,7 +146,7 @@ cfr_static <- function(data,
   # check for excessive missing date and throw an error
   stopifnot(
     "Input data must have sequential dates with none missing or duplicated" =
-      identical(unique(as.numeric(diff(data$date))), 1) # use numeric 1, not integer
+      identical(unique(as.numeric(diff(data$date))), 1) # use numeric 1
     # this solution works when df$date is `Date`
     # this may need more thought for dates that are integers, POSIXct,
     # or other units; consider the units package

--- a/R/cfr_time_varying.R
+++ b/R/cfr_time_varying.R
@@ -120,7 +120,7 @@ cfr_time_varying <- function(data,
 
   stopifnot(
     "Input data must have sequential dates with none missing or duplicated" =
-      identical(unique(diff(data$date)), 1), # use numeric 1, not integer
+      identical(unique(as.numeric(diff(data$date))), 1), # use numeric 1, not integer
     "`smoothing_window` must be an odd number greater than 0" =
       (smoothing_window %% 2 != 0),
     "`delay_density` must be a function with a single required argument,

--- a/R/cfr_time_varying.R
+++ b/R/cfr_time_varying.R
@@ -120,7 +120,7 @@ cfr_time_varying <- function(data,
 
   stopifnot(
     "Input data must have sequential dates with none missing or duplicated" =
-      identical(unique(as.numeric(diff(data$date))), 1), # use numeric 1, not integer
+      identical(unique(as.numeric(diff(data$date))), 1), # use numeric 1
     "`smoothing_window` must be an odd number greater than 0" =
       (smoothing_window %% 2 != 0),
     "`delay_density` must be a function with a single required argument,


### PR DESCRIPTION
A new change in r-devel affects how unique(<difftime>) behaves. Previously, calling unique() on a difftime object returned a numeric vector, but now it retains its difftime class.

Hence the following check in `cfr_static`, `cfr_rolling` and `cfr_time_varying` now fails:
```r
identical(unique(diff(data$date)), 1)
```
because diff(data$date) returns a difftime object, and unique(diff(data$date)) no longer simplifies to numeric.

It has therefore been replaced with:
```r
identical(unique(as.numeric(diff(data$date))), 1)
```

Once this PR is complete, we'll release version 0.13 onto CRAN with the above fix.