### PR TITLE
Use DOI link for article in `estimate_from_individual_data.Rmd`

### DIFF
--- a/vignettes/estimate_from_individual_data.Rmd
+++ b/vignettes/estimate_from_individual_data.Rmd
@@ -95,7 +95,7 @@ And hence this will not simplify to provide an unbiased estimate of $p$, as if w
 
 ## Estimation based on expected number of known death outcomes
 
-If the delay from onset-to-death and onset-to-recovery are different, one option is to use [survival analysis methods](https://academic.oup.com/aje/article/162/5/479/82647) to estimate relative hazards (i.e. fatality risk) over time.
+If the delay from onset-to-death and onset-to-recovery are different, one option is to use [survival analysis methods](https://doi.org/10.1093/aje/kwi230) to estimate relative hazards (i.e. fatality risk) over time.
 
 However, if we are only interested in an overall estimate of CFR, a simpler alternative is to first calculate the number of cases in the linelist that we would expect to have a known outcome by this point if the outcome were fatal:
 $$


### PR DESCRIPTION
This PR fixes the R CMD check NOTE flagged by CRAN:

>  Found the following (possibly) invalid URLs:
     URL: https://academic.oup.com/aje/article/162/5/479/82647
       From: inst/doc/estimate_from_individual_data.html
       Status: 403
       Message: Forbidden
   Please use DOIs for the following publisher URLs:
     https://academic.oup.com/aje/article/162/5/479/82647

by replacing the previous link with the DOI link.