### PR TITLE
Use {simulist} in individual level data vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,9 +47,12 @@ Suggests:
     purrr,
     rmarkdown,
     scales,
+    simulist,
     spelling,
     testthat (>= 3.0.0),
     tidyr
+Remotes:
+    epiverse-trace/simulist@main
 VignetteBuilder: 
     knitr
 Config/Needs/website: epiverse-trace/epiversetheme

--- a/vignettes/estimate_from_individual_data.Rmd
+++ b/vignettes/estimate_from_individual_data.Rmd
@@ -123,19 +123,19 @@ To compare these methods, i.e. filtering out cases without known outcomes vs usi
 # Set seed for reproducibility
 set.seed(1)
 
-# Deaths: assume mean delay = 5 days, sd = 5 days
+# Deaths: assume mean delay = 10 days, sd = 3 days
 onset_to_death <- function(x) {
-  dlnorm(x, meanlog = 1.262864, sdlog = 0.8325546)
+  dlnorm(x, meanlog = 2.259496, sdlog = 0.2935604)
 }
 
 # Simulate data
-# Recoveries: assume mean delay = 15 days, sd = 5 days
+# Recoveries: assume mean delay = 30 days, sd = 3 days
 linelist <- sim_linelist(
   onset_to_death = function(x) {
-    rlnorm(n = x, meanlog = 1.262864, sdlog = 0.8325546)
+    rlnorm(n = x, meanlog = 2.259496, sdlog = 0.2935604)
   },
   onset_to_recovery = function(x) {
-    rlnorm(n = x, meanlog = 2.65537, sdlog = 0.3245928)
+    rlnorm(n = x, meanlog = 3.211727, sdlog = 0.1195713)
   },
   hosp_risk = 0,
   hosp_death_risk = 0,
@@ -199,9 +199,9 @@ First, we calculate CFR by filtering to focus only on cases with known outcomes:
 
 ```{r}
 # Filter on known outcomes
-total_deaths <- sum(trunc_linelist$outcome == "died", na.rm = TRUE)
+total_deaths <- sum(trunc_linelist$outcome == "died" & trunc_linelist$date_outcome < max_obs, na.rm = TRUE)
 total_outcomes <- total_deaths +
-  sum(trunc_linelist$outcome == "recovered", na.rm = TRUE)
+  sum(trunc_linelist$outcome == "recovered" & trunc_linelist$date_outcome < max_obs, na.rm = TRUE)
 
 # Calculate CFR with 95% CI
 cfr_filter <- binom.test(total_deaths, total_outcomes)

--- a/vignettes/estimate_from_individual_data.Rmd
+++ b/vignettes/estimate_from_individual_data.Rmd
@@ -199,10 +199,10 @@ First, we calculate CFR by filtering to focus only on cases with known outcomes:
 
 ```{r}
 # Filter on known outcomes
-total_deaths <- sum(trunc_linelist$outcome == "died" & 
+total_deaths <- sum(trunc_linelist$outcome == "died" &
                       trunc_linelist$date_outcome < max_obs, na.rm = TRUE)
 total_outcomes <- total_deaths +
-  sum(trunc_linelist$outcome == "recovered" & 
+  sum(trunc_linelist$outcome == "recovered" &
         trunc_linelist$date_outcome < max_obs, na.rm = TRUE)
 
 # Calculate CFR with 95% CI

--- a/vignettes/estimate_from_individual_data.Rmd
+++ b/vignettes/estimate_from_individual_data.Rmd
@@ -148,7 +148,7 @@ trunc_linelist <- truncate_linelist(
 )
 ```
 
-```{r fig.cap = "Individual level timings of onsets and outcomes, for individuals with a known outcome as of 20th Jan 2024.", class.source = 'fold-hide'}
+```{r fig.cap = paste0("Individual level timings of onsets and outcomes, for individuals with a known outcome as of ",  format(max_obs, format = "%d %B %Y"), "."), class.source = 'fold-hide'}
 # Create plot with lines linking onset and outcome
 ggplot(data = trunc_linelist) +
   geom_segment(
@@ -185,7 +185,8 @@ ggplot(data = trunc_linelist) +
   scale_color_manual(values = c("darkred", "darkgreen")) +
   scale_shape_manual(values = c(16, 17)) +
   labs(colour = "Outcome type", shape = "Outcome type") +
-  theme_minimal()
+  theme_minimal() +
+  theme(legend.position = "bottom")
 ```
 
 First, we calculate CFR by filtering to focus only on cases with known outcomes:
@@ -198,10 +199,13 @@ total_outcomes <- total_deaths +
 
 # Calculate CFR with 95% CI
 cfr_filter <- binom.test(total_deaths, total_outcomes)
-cfr_estimate <- signif(
+cfr_estimate_unadjusted <- signif(
   as.numeric(c(cfr_filter$estimate, cfr_filter$conf.int)), 3
 )
-cfr_estimate
+names(cfr_estimate_unadjusted) <- c(
+  "severity_estimate", "severity_low", "severity_high"
+)
+cfr_estimate_unadjusted
 ```
 
 Next, we calculate CFR based on expected fatal outcomes known to date, using `cfr_static()`
@@ -232,9 +236,10 @@ df <- prepare_data(
   deaths_variable = "date_death"
 )
 
-cfr_static(df, delay_density = onset_to_death)
+cfr_estimate_adjusted <- cfr_static(df, delay_density = onset_to_death)
+cfr_estimate_adjusted
 ```
-Hence in this particular simulation, the `cfr_static()` method recovers the correct CFR of 10% (95% CI: 8.3-12.0%), whereas the filtering method produces a biased estimate of 26.4% (17.6-37.0%).
+Hence in this particular simulation, the `cfr_static()` method recovers the correct CFR of `r cfr_estimate_adjusted[["severity_estimate"]] * 100`% (95% CI: `r cfr_estimate_adjusted[["severity_low"]] * 100` - `r cfr_estimate_adjusted[["severity_high"]] * 100`%), whereas the filtering method produces a biased estimate of `r cfr_estimate_unadjusted[["severity_estimate"]] * 100`% (95% CI: `r cfr_estimate_unadjusted[["severity_low"]] * 100` - `r cfr_estimate_unadjusted[["severity_high"]] * 100`%).
 
 ## Deaths reported but not recoveries
 

--- a/vignettes/estimate_from_individual_data.Rmd
+++ b/vignettes/estimate_from_individual_data.Rmd
@@ -42,7 +42,8 @@ We want to estimate the case fatality risk (CFR) from individual-level linelist 
 # load {cfr}
 library(cfr)
 
-# packages to wrangle and plot data
+# packages to simulate, wrangle and plot data
+library(simulist)
 library(dplyr)
 library(magrittr)
 library(ggplot2)
@@ -119,149 +120,119 @@ This is the calculation performed by `cfr_static()`, and hence this function can
 To compare these methods, i.e. filtering out cases without known outcomes vs using the `cfr_static` function, we first simulate 1000 case onset timings and outcomes (i.e. deaths and recoveries)
 
 ```{r}
-# Simulate data
-nn <- 1e3 # Number of cases to simulate
-pp <- 0.1 # Assumed CFR
-set.seed(10) # Set seed for reproducibility
+# Set seed for reproducibility
+set.seed(1)
 
-# Generate random case onset timings in Jan & Feb 2024
-case_onsets <- as.Date("2024-01-01") + sample.int(60, nn, replace = TRUE)
+# Deaths: assume mean delay = 5 days, sd = 5 days
+onset_to_death <- function(x) dlnorm(x, meanlog = 1.262864, sdlog = 0.8325546)
+
+# Simulate data
+# Recoveries: assume mean delay = 15 days, sd = 5 days
+linelist <- sim_linelist(
+  onset_to_death = function(x) rlnorm(n = x, meanlog = 1.262864, sdlog = 0.8325546), 
+  onset_to_recovery = function(x) rlnorm(n = x, meanlog = 2.65537, sdlog = 0.3245928),
+  hosp_risk = 0,
+  hosp_death_risk = 0,
+  non_hosp_death_risk = 0.1, # Assumed CFR (10%)
+  outbreak_size = c(1e3, 1e4), # Number of cases to simulate
+  outbreak_start_date = as.Date("2024-01-01")
+)
 
 # Define current date of data availability (i.e. max follow up)
-max_obs <- as.Date("2024-01-20")
+max_obs <- as.Date("2024-04-01")
 
-# Sample delays from onset to outcome
-
-# 1. Deaths: assume mean delay = 5 days, sd = 5 days
-log_param <- c(meanlog = 1.262864, sdlog = 0.8325546)
-delay_death <- function(x) {
-  dlnorm(x,
-    meanlog = log_param[["meanlog"]],
-    sdlog = log_param[["sdlog"]]
-  )
-}
-outcome_death <- round(rlnorm(round(nn * pp),
-  meanlog = log_param[["meanlog"]],
-  sdlog = log_param[["sdlog"]]
-))
-
-# 2. Recoveries: assume mean delay = 15 days, sd = 5 days
-log_param <- c(meanlog = 2.65537, sdlog = 0.3245928)
-outcome_recovery <- round(rlnorm(round(nn * (1 - pp)),
-  meanlog = log_param[["meanlog"]],
-  sdlog = log_param[["sdlog"]]
-))
-
-# Create vector of outcome dates
-all_outcomes <- case_onsets + c(outcome_death, outcome_recovery)
-
-# Create vector of outcome types
-type_outcome <- c(rep("D", length(outcome_death)),
-                  rep("R", length(outcome_recovery)))
-
-# Create vector of known outcomes as of max_obs
-known_outcomes <- type_outcome
-known_outcomes[(all_outcomes > max_obs)] <- ""
+# Truncate line list to known outcomes as of max_obs
+trunc_linelist <- truncate_linelist(
+  linelist = linelist,
+  truncation_day = max_obs
+)
 ```
 
 ```{r fig.cap = "Individual level timings of onsets and outcomes, for individuals with a known outcome as of 20th Jan 2024.", class.source = 'fold-hide'}
-# Create a data frame with onset and outcome dates, and outcome type
-data <- data.frame(
-  id = 1:nn,
-  case_onsets = case_onsets,
-  outcome_dates = all_outcomes,
-  outcome_type = type_outcome,
-  known_outcome = known_outcomes
-)
-
-# Filter out unknown outcomes (after the max_obs date)
-data <- data %>% filter(nzchar(known_outcome))
-
-# Arrange data by onset date
-data <- data %>%
-  arrange(case_onsets) %>%
-  mutate(id_ordered = row_number()) # Assign a new 'id_ordered'
-
-# Prepare data for plotting (onset and outcome events in same column)
-plot_data <- data %>%
-  tidyr::pivot_longer(
-    cols = c(case_onsets, outcome_dates),
-    names_to = "event_type",
-    values_to = "date"
-  ) %>%
-  mutate(
-    event_label = ifelse(event_type == "case_onsets", "Onset", "Outcome")
-  )
-
 # Create plot with lines linking onset and outcome
-ggplot() +
+ggplot(data = trunc_linelist) +
   geom_segment(
-    data = data, aes(x = case_onsets,
-                     xend = outcome_dates,
-                     y = id_ordered,
-                     yend = id_ordered),
-    color = ifelse(data$outcome_type == "D", "red", "green"),
-    size = 0.5
+    mapping = aes(
+      x = date_onset, 
+      xend = date_outcome,
+      y = id,
+      yend = id,
+      colour = outcome
+    )
   ) +
-  geom_point(data = plot_data, aes(x = date,
-                                   y = id_ordered,
-                                   color = outcome_type,
-                                   shape = event_label),
-             size = 2) +
-  geom_vline(xintercept = as.numeric(max_obs),
-             linetype = "dashed",
-             color = "black",
-             size = 0.5) +
-  scale_color_manual(values = c(D = "darkred", R = "darkgreen")) +
-  scale_shape_manual(values = c(Onset = 16, Outcome = 17)) +
-  labs(
-    x = "Date",
-    y = "Individual (Ordered by onset date)",
-    color = "Outcome type",
-    shape = "Event type"
+  geom_point(
+    mapping = aes(
+      x = date_onset, 
+      y = id,
+      colour = outcome
+    ),
+    shape = 1
   ) +
+  geom_point(
+    mapping = aes(
+      x = date_outcome, 
+      y = id,
+      colour = outcome,
+      shape = outcome
+    )
+  ) +
+  geom_vline(
+    mapping = aes(xintercept = max_obs), 
+    linetype = "dashed"
+  ) +
+  scale_x_date(name = "Date") +
+  scale_y_continuous(name = "Individual") +
+  scale_color_manual(values = c("darkred", "darkgreen")) +
+  scale_shape_manual(values = c(16, 17)) +
+  labs(colour = "Outcome type", shape = "Outcome type") +
   theme_minimal()
 ```
 
 First, we calculate CFR by filtering to focus only on cases with known outcomes:
+
 ```{r}
 # Filter on known outcomes
-total_deaths <- sum(known_outcomes == "D")
-total_outcomes <- (total_deaths + sum(known_outcomes == "R"))
+total_deaths <- sum(trunc_linelist$outcome == "died", na.rm = TRUE)
+total_outcomes <- total_deaths + 
+  sum(trunc_linelist$outcome == "recovered", na.rm = TRUE)
 
 # Calculate CFR with 95% CI
 cfr_filter <- binom.test(total_deaths, total_outcomes)
-cfr_estimate <- (signif(as.numeric(c(cfr_filter$estimate,
-                                     cfr_filter$conf.int)), 3))
+cfr_estimate <- signif(
+  as.numeric(c(cfr_filter$estimate, cfr_filter$conf.int)), 3
+)
 cfr_estimate
 ```
 
 Next, we calculate CFR based on expected fatal outcomes known to date, using `cfr_static()`
-```{r}
-# Get times of death for fatal outcomes
-death_times <- (case_onsets)[type_outcome == "D"] + outcome_death
 
-# Create a single data.frame with event types
-events <- data.frame(
-  dates = c(case_onsets, death_times),
-  event = c(rep("cases", length(case_onsets)),
-            rep("deaths", length(death_times)))
-)
+```{r}
+trunc_linelist_wide <- trunc_linelist %>%
+  pivot_wider(
+    names_from = outcome,
+    values_from = date_outcome
+  ) %>%
+  rename(
+    date_death = died,
+    date_recovery = recovered
+  )
 
 # Use incidence2 to calculate counts of cases and deaths by day
-counts <- incidence2::incidence(events,
-                                date_index = "dates",
-                                groups = "event",
-                                complete_dates = TRUE)
+counts <- incidence(
+  trunc_linelist_wide, 
+  date_index = c("date_onset", "date_death"), 
+  interval = "daily",
+  complete_dates = TRUE
+)
 
 # Pivot incidence object to get data.frame with counts for cases and deaths
-df <- counts %>%
-  tidyr::pivot_wider(names_from = event,
-                     values_from = count,
-                     values_fill = 0) %>%
-  dplyr::rename(date = date_index)
+df <- prepare_data(
+  counts, 
+  cases_variable = "date_onset", 
+  deaths_variable = "date_death"
+)
 
-cfr_static(df, delay_death)
+cfr_static(df, delay_density = onset_to_death)
 ```
 Hence in this particular simulation, the `cfr_static()` method recovers the correct CFR of 10% (95% CI: 8.3-12.0%), whereas the filtering method produces a biased estimate of 26.4% (17.6-37.0%).
 
@@ -290,6 +261,7 @@ E(p) = \frac{\text{Total deaths}}{\sum_{t} \sum_j f_{j} I_{t-j} }
 $$
 
 We can do this in _cfr_ using the `estimate_outcomes()` function to calculate the expected number of cases with known fatal outcomes in the above denominator:
+
 ```{r}
 # Calculate total deaths and total cases
 total_deaths <- sum(df$deaths)
@@ -300,7 +272,7 @@ df_case <- df
 df_case$deaths <- 0
 
 # Calculate the expected number of known fatal outcomes over time
-e_outcomes <- estimate_outcomes(df_case, delay_death)
+e_outcomes <- estimate_outcomes(df_case, delay_density = onset_to_death)
 
 # Calculate the CFR
 total_deaths / (total_cases * tail(e_outcomes$u_t, 1))
@@ -316,7 +288,7 @@ df_cases$deaths <- 0
 df_cases$deaths[nrow(df_cases)] <- sum(df$deaths)
 
 # Calculate CFR
-cfr_static(df_cases, delay_death)
+cfr_static(df_cases, delay_density = onset_to_death)
 ```
 
 ## Only total cases and deaths reported

--- a/vignettes/estimate_from_individual_data.Rmd
+++ b/vignettes/estimate_from_individual_data.Rmd
@@ -117,7 +117,7 @@ This is the calculation performed by `cfr_static()`, and hence this function can
 
 ## Simulated comparison of above methods
 
-To compare these methods, i.e. filtering out cases without known outcomes vs using the `cfr_static` function, we first simulate 1000 case onset timings and outcomes (i.e. deaths and recoveries)
+To compare these methods, i.e. filtering out cases without known outcomes vs using the `cfr_static` function, we first simulate a linelist with at least 1000 cases with onset timings and outcomes (i.e. deaths and recoveries)
 
 ```{r}
 # Set seed for reproducibility

--- a/vignettes/estimate_from_individual_data.Rmd
+++ b/vignettes/estimate_from_individual_data.Rmd
@@ -239,7 +239,7 @@ df <- prepare_data(
 cfr_estimate_adjusted <- cfr_static(df, delay_density = onset_to_death)
 cfr_estimate_adjusted
 ```
-Hence in this particular simulation, the `cfr_static()` method recovers the correct CFR of `r cfr_estimate_adjusted[["severity_estimate"]] * 100`% (95% CI: `r cfr_estimate_adjusted[["severity_low"]] * 100` - `r cfr_estimate_adjusted[["severity_high"]] * 100`%), whereas the filtering method produces a biased estimate of `r cfr_estimate_unadjusted[["severity_estimate"]] * 100`% (95% CI: `r cfr_estimate_unadjusted[["severity_low"]] * 100` - `r cfr_estimate_unadjusted[["severity_high"]] * 100`%).
+Hence in this particular simulation, the `cfr_static()` method recovers an estimates of `r cfr_estimate_adjusted[["severity_estimate"]] * 100`% (95% CI: `r cfr_estimate_adjusted[["severity_low"]] * 100` - `r cfr_estimate_adjusted[["severity_high"]] * 100`%), close to the correct CFR, whereas the filtering method produces a biased estimate of `r cfr_estimate_unadjusted[["severity_estimate"]] * 100`% (95% CI: `r cfr_estimate_unadjusted[["severity_low"]] * 100` - `r cfr_estimate_unadjusted[["severity_high"]] * 100`%).
 
 ## Deaths reported but not recoveries
 
@@ -280,9 +280,10 @@ df_case$deaths <- 0
 e_outcomes <- estimate_outcomes(df_case, delay_density = onset_to_death)
 
 # Calculate the CFR
-total_deaths / (total_cases * tail(e_outcomes$u_t, 1))
+cfr_estimate <- total_deaths / (total_cases * tail(e_outcomes$u_t, 1))
+cfr_estimate
 ```
-As before, this produces a point estimate of 10.4%, because it is the same underlying method: the internal function code in `cfr_static()`, which calls `estimate_outcomes()`, also tallies up total death. An arguably more elegant approach is to therefore add total deaths to the case data.frame, and use as an input for `cfr_static()`:
+As before, this produces a point estimate of `r signif(cfr_estimate * 100, 4)`%, because it is the same underlying method: the internal function code in `cfr_static()`, which calls `estimate_outcomes()`, also tallies up total death. An arguably more elegant approach is to therefore add total deaths to the case data.frame, and use as an input for `cfr_static()`:
 
 ```{r}
 # Create data.frame with cases over time only

--- a/vignettes/estimate_from_individual_data.Rmd
+++ b/vignettes/estimate_from_individual_data.Rmd
@@ -124,13 +124,19 @@ To compare these methods, i.e. filtering out cases without known outcomes vs usi
 set.seed(1)
 
 # Deaths: assume mean delay = 5 days, sd = 5 days
-onset_to_death <- function(x) dlnorm(x, meanlog = 1.262864, sdlog = 0.8325546)
+onset_to_death <- function(x) {
+  dlnorm(x, meanlog = 1.262864, sdlog = 0.8325546)
+}
 
 # Simulate data
 # Recoveries: assume mean delay = 15 days, sd = 5 days
 linelist <- sim_linelist(
-  onset_to_death = function(x) rlnorm(n = x, meanlog = 1.262864, sdlog = 0.8325546), 
-  onset_to_recovery = function(x) rlnorm(n = x, meanlog = 2.65537, sdlog = 0.3245928),
+  onset_to_death = function(x) {
+    rlnorm(n = x, meanlog = 1.262864, sdlog = 0.8325546)
+  },
+  onset_to_recovery = function(x) {
+    rlnorm(n = x, meanlog = 2.65537, sdlog = 0.3245928)
+  },
   hosp_risk = 0,
   hosp_death_risk = 0,
   non_hosp_death_risk = 0.1, # Assumed CFR (10%)
@@ -153,7 +159,7 @@ trunc_linelist <- truncate_linelist(
 ggplot(data = trunc_linelist) +
   geom_segment(
     mapping = aes(
-      x = date_onset, 
+      x = date_onset,
       xend = date_outcome,
       y = id,
       yend = id,
@@ -162,7 +168,7 @@ ggplot(data = trunc_linelist) +
   ) +
   geom_point(
     mapping = aes(
-      x = date_onset, 
+      x = date_onset,
       y = id,
       colour = outcome
     ),
@@ -170,14 +176,14 @@ ggplot(data = trunc_linelist) +
   ) +
   geom_point(
     mapping = aes(
-      x = date_outcome, 
+      x = date_outcome,
       y = id,
       colour = outcome,
       shape = outcome
     )
   ) +
   geom_vline(
-    mapping = aes(xintercept = max_obs), 
+    mapping = aes(xintercept = max_obs),
     linetype = "dashed"
   ) +
   scale_x_date(name = "Date") +
@@ -194,7 +200,7 @@ First, we calculate CFR by filtering to focus only on cases with known outcomes:
 ```{r}
 # Filter on known outcomes
 total_deaths <- sum(trunc_linelist$outcome == "died", na.rm = TRUE)
-total_outcomes <- total_deaths + 
+total_outcomes <- total_deaths +
   sum(trunc_linelist$outcome == "recovered", na.rm = TRUE)
 
 # Calculate CFR with 95% CI
@@ -223,16 +229,16 @@ trunc_linelist_wide <- trunc_linelist %>%
 
 # Use incidence2 to calculate counts of cases and deaths by day
 counts <- incidence(
-  trunc_linelist_wide, 
-  date_index = c("date_onset", "date_death"), 
+  trunc_linelist_wide,
+  date_index = c("date_onset", "date_death"),
   interval = "daily",
   complete_dates = TRUE
 )
 
 # Pivot incidence object to get data.frame with counts for cases and deaths
 df <- prepare_data(
-  counts, 
-  cases_variable = "date_onset", 
+  counts,
+  cases_variable = "date_onset",
   deaths_variable = "date_death"
 )
 

--- a/vignettes/estimate_from_individual_data.Rmd
+++ b/vignettes/estimate_from_individual_data.Rmd
@@ -199,9 +199,11 @@ First, we calculate CFR by filtering to focus only on cases with known outcomes:
 
 ```{r}
 # Filter on known outcomes
-total_deaths <- sum(trunc_linelist$outcome == "died" & trunc_linelist$date_outcome < max_obs, na.rm = TRUE)
+total_deaths <- sum(trunc_linelist$outcome == "died" & 
+                      trunc_linelist$date_outcome < max_obs, na.rm = TRUE)
 total_outcomes <- total_deaths +
-  sum(trunc_linelist$outcome == "recovered" & trunc_linelist$date_outcome < max_obs, na.rm = TRUE)
+  sum(trunc_linelist$outcome == "recovered" & 
+        trunc_linelist$date_outcome < max_obs, na.rm = TRUE)
 
 # Calculate CFR with 95% CI
 cfr_filter <- binom.test(total_deaths, total_outcomes)


### PR DESCRIPTION
This PR updates the `estimate_from_individual_data.Rmd` vignette to use {simulist} to simplify the simulation step and use the truncation functionality to correctly truncate the data.

It also updates the plot of onset and outcome delay by including cases that have symptom onset before the truncation date but do not yet have an outcome (right censored). 

In text R code is added to ensure the case fatality risk (CFR) estimates exactly match and are kept up-to-date with the code chunks. 

{simulist} is added as a suggested dependency for use in the vignettes. **Note** this uses the GitHub version of {simulist} so this will need changing once the new version of {simulist} is released on CRAN. 