### PR TITLE
Fix README.Rmd typo: Correct day count

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -66,7 +66,7 @@ library(cfr)
 # Load the Ebola 1976 data provided with the package
 data(ebola1976)
 
-# Focus on the first 20 days the outbreak
+# Focus on the first 30 days of the outbreak
 ebola1976_first_30 <- ebola1976[1:30, ]
 
 # Calculate the static CFR without correcting for delays


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x ] I have read the CONTRIBUTING guidelines
- [ x] A new item has been added to `NEWS.md`       - Not applicable for a documentation-only change.
- [ x] Tests for the changes have been added (for bug fixes / features)   - Not applicable for a documentation-only change.
- [x ] Docs have been added / updated (for bug fixes / features)
- [ x] Checks have been run locally and pass    - Not applicable for a documentation-only change.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
README.Rmd update


* **What is the current behavior?** (You can also link to an open issue here)
The README.Rmd file contains a typo in a code example, saying  '20 days the outbreak' instead of '30 days of the outbreak'.

* **What is the new behavior (if this is a feature change)?**
N/A

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
